### PR TITLE
[NF] Add full bag alert on raid join

### DIFF
--- a/game/src/main/java/ru/homyakin/seeker/locale/common/CommonLocalization.java
+++ b/game/src/main/java/ru/homyakin/seeker/locale/common/CommonLocalization.java
@@ -666,6 +666,10 @@ public class CommonLocalization {
         return resources.getOrDefault(language, CommonResource::cancelEventLocked);
     }
 
+    public static String fullBagAlertOnRaidJoin(Language language) {
+        return resources.getOrDefault(language, CommonResource::fullBagAlertOnRaidJoin);
+    }
+
     private static String formatRaidItemFull(Language language, Optional<RaidItem> raidItem) {
         if (raidItem.isEmpty()) {
             return "";

--- a/game/src/main/java/ru/homyakin/seeker/locale/common/CommonResource.java
+++ b/game/src/main/java/ru/homyakin/seeker/locale/common/CommonResource.java
@@ -45,6 +45,7 @@ public record CommonResource(
     String raidGoldRewardPercentEffect,
     String itemFoundChancePercentEffect,
     String groupBuildingEffectLine,
-    String groupInfoPassiveEffectsSection
+    String groupInfoPassiveEffectsSection,
+    String fullBagAlertOnRaidJoin
 ) {
 }

--- a/game/src/main/java/ru/homyakin/seeker/telegram/command/common/world_raid/JoinWorldRaidExecutor.java
+++ b/game/src/main/java/ru/homyakin/seeker/telegram/command/common/world_raid/JoinWorldRaidExecutor.java
@@ -2,6 +2,11 @@ package ru.homyakin.seeker.telegram.command.common.world_raid;
 
 import org.springframework.stereotype.Component;
 import ru.homyakin.seeker.game.event.world_raid.action.JoinWorldRaidCommand;
+import ru.homyakin.seeker.game.item.ItemService;
+import ru.homyakin.seeker.game.personage.PersonageService;
+import ru.homyakin.seeker.game.personage.models.PersonageId;
+import ru.homyakin.seeker.locale.Language;
+import ru.homyakin.seeker.locale.common.CommonLocalization;
 import ru.homyakin.seeker.locale.world_raid.WorldRaidLocalization;
 import ru.homyakin.seeker.telegram.TelegramSender;
 import ru.homyakin.seeker.telegram.command.CommandExecutor;
@@ -12,15 +17,21 @@ import ru.homyakin.seeker.telegram.utils.TelegramMethods;
 public class JoinWorldRaidExecutor extends CommandExecutor<JoinWorldRaid> {
     private final UserService userService;
     private final JoinWorldRaidCommand joinWorldRaidCommand;
+    private final PersonageService personageService;
+    private final ItemService itemService;
     private final TelegramSender telegramSender;
 
     public JoinWorldRaidExecutor(
         UserService userService,
         JoinWorldRaidCommand joinWorldRaidCommand,
+        PersonageService personageService,
+        ItemService itemService,
         TelegramSender telegramSender
     ) {
         this.userService = userService;
         this.joinWorldRaidCommand = joinWorldRaidCommand;
+        this.personageService = personageService;
+        this.itemService = itemService;
         this.telegramSender = telegramSender;
     }
 
@@ -30,10 +41,23 @@ public class JoinWorldRaidExecutor extends CommandExecutor<JoinWorldRaid> {
         final var result = joinWorldRaidCommand.execute(user.personageId());
         final var text = result.fold(
             error -> WorldRaidLocalization.joinError(user.language(), error),
-            _ -> WorldRaidLocalization.successJoin(user.language())
+            _ -> joinWorldRaidCallbackText(user.language(), user.personageId())
         );
         telegramSender.send(
             TelegramMethods.createAnswerCallbackQuery(command.callbackId(), text)
         );
+    }
+
+    private String joinWorldRaidCallbackText(Language language, PersonageId personageId) {
+        final var builder = new StringBuilder(WorldRaidLocalization.successJoin(language));
+        if (isBagFull(personageId)) {
+            builder.append("\n").append(CommonLocalization.fullBagAlertOnRaidJoin(language));
+        }
+        return builder.toString();
+    }
+
+    private boolean isBagFull(PersonageId personageId) {
+        final var personage = personageService.getByIdForce(personageId);
+        return !personage.hasSpaceInBagForItems(itemService.getPersonageItems(personageId));
     }
 }

--- a/game/src/main/java/ru/homyakin/seeker/telegram/command/group/raid/JoinRaidExecutor.java
+++ b/game/src/main/java/ru/homyakin/seeker/telegram/command/group/raid/JoinRaidExecutor.java
@@ -4,6 +4,10 @@ import org.springframework.stereotype.Component;
 
 import ru.homyakin.seeker.game.event.raid.RaidService;
 import ru.homyakin.seeker.game.event.raid.models.AddPersonageToRaidError;
+import ru.homyakin.seeker.game.item.ItemService;
+import ru.homyakin.seeker.game.personage.PersonageService;
+import ru.homyakin.seeker.game.personage.models.PersonageId;
+import ru.homyakin.seeker.locale.Language;
 import ru.homyakin.seeker.locale.common.CommonLocalization;
 import ru.homyakin.seeker.locale.raid.RaidLocalization;
 import ru.homyakin.seeker.telegram.TelegramSender;
@@ -18,15 +22,21 @@ import ru.homyakin.seeker.telegram.utils.TelegramMethods;
 public class JoinRaidExecutor extends CommandExecutor<JoinRaid> {
     private final GroupUserService groupUserService;
     private final RaidService raidService;
+    private final PersonageService personageService;
+    private final ItemService itemService;
     private final TelegramSender telegramSender;
 
     public JoinRaidExecutor(
         GroupUserService groupUserService,
         RaidService raidService,
+        PersonageService personageService,
+        ItemService itemService,
         TelegramSender telegramSender
     ) {
         this.groupUserService = groupUserService;
         this.raidService = raidService;
+        this.personageService = personageService;
+        this.itemService = itemService;
         this.telegramSender = telegramSender;
     }
 
@@ -65,22 +75,38 @@ public class JoinRaidExecutor extends CommandExecutor<JoinRaid> {
                     )
                     .build()
             );
-            if (result.get().isExhausted()) {
-                telegramSender.send(
-                    TelegramMethods.createAnswerCallbackQuery(
-                        command.callbackId(),
-                        RaidLocalization.exhaustedAlert(group.language())
+            telegramSender.send(
+                TelegramMethods.createAnswerCallbackQuery(
+                    command.callbackId(),
+                    joinRaidCallbackText(
+                        group.language(),
+                        result.get().isExhausted(),
+                        isBagFull(user.personageId())
                     )
-                );
-            } else {
-                telegramSender.send(
-                    TelegramMethods.createAnswerCallbackQuery(
-                        command.callbackId(),
-                        RaidLocalization.successJoinRaid(group.language())
-                    )
-                );
-            }
+                )
+            );
         }
+    }
+
+    private String joinRaidCallbackText(Language language, boolean isExhausted, boolean isBagFull) {
+        final var builder = new StringBuilder();
+        if (isExhausted) {
+            builder.append(RaidLocalization.exhaustedAlert(language));
+        } else {
+            builder.append(RaidLocalization.successJoinRaid(language));
+        }
+        if (isBagFull) {
+            if (!builder.isEmpty()) {
+                builder.append("\n");
+            }
+            builder.append(CommonLocalization.fullBagAlertOnRaidJoin(language));
+        }
+        return builder.toString();
+    }
+
+    private boolean isBagFull(PersonageId personageId) {
+        final var personage = personageService.getByIdForce(personageId);
+        return !personage.hasSpaceInBagForItems(itemService.getPersonageItems(personageId));
     }
 
     private String mapErrorToUserMessage(AddPersonageToRaidError error, GroupTg group, JoinRaid command) {

--- a/game/src/main/resources/localization/en/common.toml
+++ b/game/src/main/resources/localization/en/common.toml
@@ -8,3 +8,5 @@ daysShort = "d"
 durationJustNow = "just now"
 
 contrabandEffect = "\n<code>-📦Contraband: ${effect} ${time_icon}${duration}</code>"
+
+fullBagAlertOnRaidJoin = "Your bag is full! Free up space — otherwise loot from the raid will be lost."

--- a/game/src/main/resources/localization/es/common.toml
+++ b/game/src/main/resources/localization/es/common.toml
@@ -159,3 +159,5 @@ raidGoldRewardPercentEffect = "+${value}% ${money_icon} al oro de incursiones"
 itemFoundChancePercentEffect = "+${value}% a la probabilidad de encontrar un objeto en incursiones"
 groupBuildingEffectLine = "\n<code>-${source_label}: ${effect}${optional_time_suffix}</code>"
 groupInfoPassiveEffectsSection = "\n\n<b>Efectos del grupo</b>${group_effect_lines}"
+
+fullBagAlertOnRaidJoin = "¡La mochila está llena! Libera espacio; si no, el botín de la incursión se perderá."

--- a/game/src/main/resources/localization/ru/common.toml
+++ b/game/src/main/resources/localization/ru/common.toml
@@ -168,3 +168,5 @@ ${participants_icon}${remain_participants}/${total_participants}
 ${health_icon}${remain_health}/${total_health}
 ${normal_attack_icon}${normal_damage_value} (${normal_damage_count}) ${crit_attack_icon}${crit_damage_value} (${crit_damage_count})
 ${damage_blocked_icon}${damage_blocked_value} (${damage_blocked_count}) ${dodge_icon}${dodged_damage_value} (${dodged_damage_count})"""
+
+fullBagAlertOnRaidJoin = "Рюкзак полон! Освободите место — иначе выпавшая в рейде вещь пропадёт."


### PR DESCRIPTION
### Summary
При успешном вступлении в локальный рейд (группа) и мировой рейд игроку показывается предупреждение, если рюкзак полон.

### Changes
_JoinRaidExecutor_ — проверка полного рюкзака после успешного join; предупреждение добавляется к ответу на callback (вместе с «успешно присоединились» или алертом о нехватке энергии).
_JoinWorldRaidExecutor_ — та же проверка при вступлении в мировой рейд из группы или канала.
