### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a Maven monorepo for **Krezar Tavern**, a Telegram MMORPG. There is no parent aggregator POM — each module builds independently. Toolchain (Temurin JDK 24, Maven, PostgreSQL 16) is preinstalled in the VM snapshot; the startup update script only refreshes Maven dependencies.
+
+### Modules / services
+
+| Path | What it is | Standard commands |
+| --- | --- | --- |
+| `game/` | Spring Boot Telegram bot (the core game). Owns the DB schema via Liquibase (`classpath:migrations/main-changelog.xml`, applied automatically on startup). Config: `game/src/main/resources/application.properties`. | Build/test/lint: `mvn -f game/pom.xml clean package` (runs Checkstyle in the `validate` phase + 285 JUnit tests). Run: `java -jar game/target/project-seeker-1.2.jar` |
+| `website-backend/` | Spring Boot REST API serving battle data from the same DB (`/api/launched-event/{id}/battle-init` and `/battle-log`). Reads the `event_battle_log` table. Has no tests. | Build: `mvn -f website-backend/pom.xml clean package`. Run: `java -jar website-backend/target/project-seeker-website-backend-1.0.jar` (port 8080) |
+| `website/battle-visualizer/` | Static single-file `index.html` battle replay UI. No build step. In prod, Caddy (`deploy/Caddyfile`) serves it and reverse-proxies `/api/*` to the backend. | Serve as static files. Load a battle via `?launchedEventId=ID` (goes through `/api`), or `?init=URL&log=URL` for raw JSON files. |
+
+### Non-obvious caveats
+
+- **PostgreSQL must be started manually** each session: `sudo service postgresql start`. The dev DB is `seeker` with role `dev`/`dev` on `localhost:5432` (matches the app defaults). The DB cluster (schema + any seeded data) persists in the VM snapshot.
+- **The DB schema is created only by the `game` module's Liquibase migrations**, which run during Spring context startup. `website-backend` does NOT run migrations, so start (at least once) the game jar against an empty `seeker` DB before using the backend.
+- **Running the game bot requires real Telegram credentials.** `TELEGRAM_TOKEN` and `TELEGRAM_USERNAME` have no defaults. With a dummy token the app boots fully (applies migrations, loads game data) and then throws only at the final `botsApplication.registerBot(...)` step (`TelegramApiErrorResponseException`) because it long-polls the real Telegram API. This is expected without a valid token — everything before bot registration is healthy. Set `LOCAL_BOT_ENABLED=true` (+ `LOCAL_BOT_HOST/PORT/SCHEMA`) to point at a local Telegram Bot API server instead of the real one.
+- `homyakin.seeker.init-game-data.type=TEST` (default in the `dev` profile) loads test game-data TOML on startup, seeding `event`, items, etc.
+- **CORS:** the backend sets no CORS headers, so the visualizer must be served from the same origin as `/api` (as Caddy does in prod). For local browser testing, put a reverse proxy in front that serves `website/` statically and proxies `/api/*` to `localhost:8080`.
+- Generate sample battle JSON (for the visualizer / to seed `event_battle_log`) without a running game by executing the `@Disabled` simulator test: `mvn -f game/pom.xml test -Dtest='BattleSimulator#logTest' -Djunit.jupiter.conditions.deactivate='*' -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false`. Output: `game/target/battle-v4-log/battle-init.json` and `battle-action-log.json`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Krezar Tavern monorepo (Telegram MMORPG) so cloud agents can build, test, lint, and run all products. Adds `AGENTS.md` documenting durable, non-obvious startup/run caveats. No application code was modified.

## Environment

- Installed (baked into VM snapshot): Temurin **JDK 24**, **Maven 3.8.7**, **PostgreSQL 16** (dev DB `seeker`, role `dev`/`dev` on `:5432`, matching app defaults).
- Startup **update script** (dependency refresh only): `mvn -DskipTests dependency:go-offline` for `game/` and `website-backend/`.

## Verified end-to-end

| Service | Command | Result |
| --- | --- | --- |
| `game` (build/test/lint) | `mvn -f game/pom.xml clean package` | BUILD SUCCESS — Checkstyle passes, **285 tests, 0 failures** |
| `game` (run) | `java -jar game/target/project-seeker-1.2.jar` | Boots + applies **113 Liquibase changesets → 56 tables**; only fails at final Telegram bot registration (no real token — external dependency) |
| `website-backend` (build) | `mvn -f website-backend/pom.xml clean package` | BUILD SUCCESS |
| `website-backend` (run) | `java -jar website-backend/target/...jar` | Started on `:8080`; `/battle-init` & `/battle-log` return **200** with game-generated data, missing event → **404** |
| `website/battle-visualizer` | static served + `/api` proxy | Loads battle `?launchedEventId=9999` through the backend and animates it |

## Hello-world (core functionality)

Generated a real battle with the game's battle engine (`BattleSimulator#logTest`), seeded it into `event_battle_log`, served it through the website-backend, and played it back in the battle-visualizer UI in a browser: HP bars drop, damage popups appear, attacker/target highlight, and the event log/counters advance.

[battle_visualizer_e2e_demo.mp4](https://cursor.com/agents/bc-d395459a-91e4-4ef9-8ceb-538fc4542023/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbattle_visualizer_e2e_demo.mp4)

[Battle visualizer loaded via backend](https://cursor.com/agents/bc-d395459a-91e4-4ef9-8ceb-538fc4542023/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbattle_visualizer_loaded.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d395459a-91e4-4ef9-8ceb-538fc4542023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d395459a-91e4-4ef9-8ceb-538fc4542023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

