### PR TITLE
[NF] Add battle position to personage equipment loadouts

### DIFF
--- a/game/src/main/java/ru/homyakin/seeker/game/duel/DuelService.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/duel/DuelService.java
@@ -183,18 +183,20 @@ public class DuelService {
         launchedEventService.updateStatus(duel.id(), EventStatus.SUCCESS);
         final var personage1 = personageService.getByIdForce(duel.initiatingPersonageId());
         final var personage2 = personageService.getByIdForce(duel.acceptingPersonageId());
-        final var combatItems = loadoutService.resolveCombatItems(
+        final var combatGear = loadoutService.resolveCombatGear(
             Set.of(personage1.id(), personage2.id()),
             EventType.DUEL
         );
+        final var firstGear = combatGear.get(personage1.id());
+        final var secondGear = combatGear.get(personage2.id());
         final var firstBattlePersonage = BattlePersonage.forCombat(
-            combatItems.getOrDefault(personage1.id(), List.of()),
+            firstGear == null ? List.of() : firstGear.items(),
             Position.FRONT,
             personage1.effects(),
             Optional.of(LocaleUtils.personageNameWithBadge(personage1))
         );
         final var secondBattlePersonage = BattlePersonage.forCombat(
-            combatItems.getOrDefault(personage2.id(), List.of()),
+            secondGear == null ? List.of() : secondGear.items(),
             Position.FRONT,
             personage2.effects(),
             Optional.of(LocaleUtils.personageNameWithBadge(personage2))

--- a/game/src/main/java/ru/homyakin/seeker/game/duel/DuelService.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/duel/DuelService.java
@@ -3,7 +3,6 @@ package ru.homyakin.seeker.game.duel;
 import io.vavr.control.Either;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import ru.homyakin.seeker.common.models.GroupId;
@@ -184,19 +183,19 @@ public class DuelService {
         final var personage1 = personageService.getByIdForce(duel.initiatingPersonageId());
         final var personage2 = personageService.getByIdForce(duel.acceptingPersonageId());
         final var combatGear = loadoutService.resolveCombatGear(
-            Set.of(personage1.id(), personage2.id()),
+            List.of(personage1, personage2),
             EventType.DUEL
         );
         final var firstGear = combatGear.get(personage1.id());
         final var secondGear = combatGear.get(personage2.id());
         final var firstBattlePersonage = BattlePersonage.forCombat(
-            firstGear == null ? List.of() : firstGear.items(),
+            firstGear.items(),
             Position.FRONT,
             personage1.effects(),
             Optional.of(LocaleUtils.personageNameWithBadge(personage1))
         );
         final var secondBattlePersonage = BattlePersonage.forCombat(
-            secondGear == null ? List.of() : secondGear.items(),
+            secondGear.items(),
             Position.FRONT,
             personage2.effects(),
             Optional.of(LocaleUtils.personageNameWithBadge(personage2))

--- a/game/src/main/java/ru/homyakin/seeker/game/event/raid/processing/RaidProcessing.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/event/raid/processing/RaidProcessing.java
@@ -29,6 +29,7 @@ import ru.homyakin.seeker.game.effect.ItemFoundChanceBonus;
 import ru.homyakin.seeker.game.effect.RaidGoldRewardBonus;
 import ru.homyakin.seeker.game.group.passive.GroupPassiveEffect;
 import ru.homyakin.seeker.game.item.loadout.action.EquipmentLoadoutService;
+import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.models.Money;
 import ru.homyakin.seeker.game.outpost.action.GroupPassiveEffectsService;
 import ru.homyakin.seeker.game.personage.PersonageService;
@@ -184,14 +185,22 @@ public class RaidProcessing {
         final var personageIds = participants.stream()
             .map(participant -> participant.personage().id())
             .collect(Collectors.toSet());
-        final var combatItemsByPersonageId = loadoutService.resolveCombatItems(personageIds, EventType.RAID);
+        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personageIds, EventType.RAID);
         return participants.stream()
-            .map(participant -> BattlePersonage.forCombat(
-                combatItemsByPersonageId.getOrDefault(participant.personage().id(), List.of()),
-                participant.personage().position(),
-                participant.personage().effects(),
-                Optional.of(LocaleUtils.personageNameWithBadge(participant.personage()))
-            ))
+            .map(participant -> {
+                final var personage = participant.personage();
+                final var combatGear = combatGearByPersonageId.get(personage.id());
+                final var items = combatGear == null ? List.<Item>of() : combatGear.items();
+                final var position = combatGear == null
+                    ? personage.position()
+                    : combatGear.positionOr(personage.position());
+                return BattlePersonage.forCombat(
+                    items,
+                    position,
+                    personage.effects(),
+                    Optional.of(LocaleUtils.personageNameWithBadge(personage))
+                );
+            })
             .toList();
     }
 

--- a/game/src/main/java/ru/homyakin/seeker/game/event/raid/processing/RaidProcessing.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/event/raid/processing/RaidProcessing.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,6 @@ import ru.homyakin.seeker.game.effect.ItemFoundChanceBonus;
 import ru.homyakin.seeker.game.effect.RaidGoldRewardBonus;
 import ru.homyakin.seeker.game.group.passive.GroupPassiveEffect;
 import ru.homyakin.seeker.game.item.loadout.action.EquipmentLoadoutService;
-import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.models.Money;
 import ru.homyakin.seeker.game.outpost.action.GroupPassiveEffectsService;
 import ru.homyakin.seeker.game.personage.PersonageService;
@@ -182,21 +180,17 @@ public class RaidProcessing {
     }
 
     private List<BattlePersonage> toBattlePersonages(List<RaidParticipant> participants) {
-        final var personageIds = participants.stream()
-            .map(participant -> participant.personage().id())
-            .collect(Collectors.toSet());
-        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personageIds, EventType.RAID);
+        final var personages = participants.stream()
+            .map(RaidParticipant::personage)
+            .toList();
+        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personages, EventType.RAID);
         return participants.stream()
             .map(participant -> {
                 final var personage = participant.personage();
                 final var combatGear = combatGearByPersonageId.get(personage.id());
-                final var items = combatGear == null ? List.<Item>of() : combatGear.items();
-                final var position = combatGear == null
-                    ? personage.position()
-                    : combatGear.positionOr(personage.position());
                 return BattlePersonage.forCombat(
-                    items,
-                    position,
+                    combatGear.items(),
+                    combatGear.battlePosition(),
                     personage.effects(),
                     Optional.of(LocaleUtils.personageNameWithBadge(personage))
                 );

--- a/game/src/main/java/ru/homyakin/seeker/game/event/world_raid/action/ProcessWorldRaidBattleCommand.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/event/world_raid/action/ProcessWorldRaidBattleCommand.java
@@ -22,6 +22,7 @@ import ru.homyakin.seeker.game.event.world_raid.entity.WorldRaidConfig;
 import ru.homyakin.seeker.game.event.world_raid.entity.WorldRaidStorage;
 import ru.homyakin.seeker.game.event.world_raid.entity.battle.WorldRaidBattleResultService;
 import ru.homyakin.seeker.game.item.loadout.action.EquipmentLoadoutService;
+import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.models.Money;
 import ru.homyakin.seeker.game.personage.event.PersonageEventService;
 import ru.homyakin.seeker.game.personage.event.WorldRaidParticipant;
@@ -138,14 +139,22 @@ public class ProcessWorldRaidBattleCommand {
         final var personageIds = participants.stream()
             .map(participant -> participant.personage().id())
             .collect(Collectors.toSet());
-        final var combatItemsByPersonageId = loadoutService.resolveCombatItems(personageIds, EventType.WORLD_RAID);
+        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personageIds, EventType.WORLD_RAID);
         return participants.stream()
-            .map(participant -> BattlePersonage.forCombat(
-                combatItemsByPersonageId.getOrDefault(participant.personage().id(), List.of()),
-                participant.personage().position(),
-                participant.personage().effects(),
-                Optional.of(LocaleUtils.personageNameWithBadge(participant.personage()))
-            ))
+            .map(participant -> {
+                final var personage = participant.personage();
+                final var combatGear = combatGearByPersonageId.get(personage.id());
+                final var items = combatGear == null ? List.<Item>of() : combatGear.items();
+                final var position = combatGear == null
+                    ? personage.position()
+                    : combatGear.positionOr(personage.position());
+                return BattlePersonage.forCombat(
+                    items,
+                    position,
+                    personage.effects(),
+                    Optional.of(LocaleUtils.personageNameWithBadge(personage))
+                );
+            })
             .toList();
     }
 

--- a/game/src/main/java/ru/homyakin/seeker/game/event/world_raid/action/ProcessWorldRaidBattleCommand.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/event/world_raid/action/ProcessWorldRaidBattleCommand.java
@@ -22,7 +22,6 @@ import ru.homyakin.seeker.game.event.world_raid.entity.WorldRaidConfig;
 import ru.homyakin.seeker.game.event.world_raid.entity.WorldRaidStorage;
 import ru.homyakin.seeker.game.event.world_raid.entity.battle.WorldRaidBattleResultService;
 import ru.homyakin.seeker.game.item.loadout.action.EquipmentLoadoutService;
-import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.models.Money;
 import ru.homyakin.seeker.game.personage.event.PersonageEventService;
 import ru.homyakin.seeker.game.personage.event.WorldRaidParticipant;
@@ -35,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 public class ProcessWorldRaidBattleCommand {
@@ -136,21 +134,17 @@ public class ProcessWorldRaidBattleCommand {
     }
 
     private List<BattlePersonage> toBattlePersonages(List<WorldRaidParticipant> participants) {
-        final var personageIds = participants.stream()
-            .map(participant -> participant.personage().id())
-            .collect(Collectors.toSet());
-        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personageIds, EventType.WORLD_RAID);
+        final var personages = participants.stream()
+            .map(WorldRaidParticipant::personage)
+            .toList();
+        final var combatGearByPersonageId = loadoutService.resolveCombatGear(personages, EventType.WORLD_RAID);
         return participants.stream()
             .map(participant -> {
                 final var personage = participant.personage();
                 final var combatGear = combatGearByPersonageId.get(personage.id());
-                final var items = combatGear == null ? List.<Item>of() : combatGear.items();
-                final var position = combatGear == null
-                    ? personage.position()
-                    : combatGear.positionOr(personage.position());
                 return BattlePersonage.forCombat(
-                    items,
-                    position,
+                    combatGear.items(),
+                    combatGear.battlePosition(),
                     personage.effects(),
                     Optional.of(LocaleUtils.personageNameWithBadge(personage))
                 );

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutService.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutService.java
@@ -21,13 +21,14 @@ import ru.homyakin.seeker.game.item.loadout.entity.DeleteLoadoutError;
 import ru.homyakin.seeker.game.item.loadout.entity.EquipmentLoadout;
 import ru.homyakin.seeker.game.item.loadout.entity.LoadoutNameValidator;
 import ru.homyakin.seeker.game.item.loadout.entity.RenameLoadoutError;
+import ru.homyakin.seeker.game.item.loadout.entity.ResolvedCombatGear;
 import ru.homyakin.seeker.game.item.loadout.entity.SaveLoadoutError;
 import ru.homyakin.seeker.game.item.loadout.entity.ToggleDefaultLoadoutError;
 import ru.homyakin.seeker.game.item.loadout.entity.ToggleDefaultLoadoutResult;
 import ru.homyakin.seeker.game.item.loadout.infra.postgres.EquipmentLoadoutDao;
 import ru.homyakin.seeker.game.item.models.Inventory;
-import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.item.models.PersonageItem;
+import ru.homyakin.seeker.game.personage.PersonageService;
 import ru.homyakin.seeker.game.personage.models.PersonageId;
 import ru.homyakin.seeker.game.personage.models.PersonageSlot;
 import ru.homyakin.seeker.utils.models.Success;
@@ -44,15 +45,18 @@ public class EquipmentLoadoutService {
     private final EquipmentLoadoutDao loadoutDao;
     private final ItemService itemService;
     private final ItemDao itemDao;
+    private final PersonageService personageService;
 
     public EquipmentLoadoutService(
         EquipmentLoadoutDao loadoutDao,
         ItemService itemService,
-        ItemDao itemDao
+        ItemDao itemDao,
+        PersonageService personageService
     ) {
         this.loadoutDao = loadoutDao;
         this.itemService = itemService;
         this.itemDao = itemDao;
+        this.personageService = personageService;
     }
 
     public List<EquipmentLoadout> list(PersonageId personageId) {
@@ -102,18 +106,21 @@ public class EquipmentLoadoutService {
         return Either.right(ToggleDefaultLoadoutResult.SET);
     }
 
-    public Map<PersonageId, List<Item>> resolveCombatItems(Set<PersonageId> personageIds, EventType eventType) {
+    public Map<PersonageId, ResolvedCombatGear> resolveCombatGear(Set<PersonageId> personageIds, EventType eventType) {
         final var equippedByPersonageId = itemService.getEquippedItemsByPersonageIds(personageIds);
+        final var result = new HashMap<PersonageId, ResolvedCombatGear>();
+        for (final var entry : equippedByPersonageId.entrySet()) {
+            result.put(entry.getKey(), ResolvedCombatGear.fromEquipped(entry.getValue()));
+        }
         if (personageIds.isEmpty() || !DEFAULT_LOADOUT_EVENT_TYPES.contains(eventType)) {
-            return equippedByPersonageId;
+            return result;
         }
 
         final var defaultLoadouts = loadoutDao.findDefaultsByPersonageIdsAndEventType(personageIds, eventType);
         if (defaultLoadouts.isEmpty()) {
-            return equippedByPersonageId;
+            return result;
         }
 
-        final var result = new HashMap<>(equippedByPersonageId);
         for (final var entry : defaultLoadouts.entrySet()) {
             final var personageId = entry.getKey();
             final var loadout = entry.getValue();
@@ -127,7 +134,13 @@ public class EquipmentLoadoutService {
             if (hasSlotConflicts(ownedLoadoutItems)) {
                 continue;
             }
-            result.put(personageId, itemService.itemsWithDefaults(ownedLoadoutItems));
+            result.put(
+                personageId,
+                ResolvedCombatGear.fromLoadout(
+                    itemService.itemsWithDefaults(ownedLoadoutItems),
+                    loadout.battlePosition()
+                )
+            );
         }
         return result;
     }
@@ -142,7 +155,8 @@ public class EquipmentLoadoutService {
             return Either.left(CreateLoadoutError.MaxLoadoutsReached.INSTANCE);
         }
         final var itemIds = currentEquippedItemIds(personageId);
-        final var id = loadoutDao.insert(personageId, validatedName.get(), itemIds);
+        final var battlePosition = personageService.getByIdForce(personageId).position();
+        final var id = loadoutDao.insert(personageId, validatedName.get(), itemIds, battlePosition);
         return Either.right(loadoutDao.findById(id).orElseThrow());
     }
 
@@ -153,7 +167,8 @@ public class EquipmentLoadoutService {
             return Either.left(SaveLoadoutError.LoadoutNotFound.INSTANCE);
         }
         final var itemIds = currentEquippedItemIds(personageId);
-        loadoutDao.updateItemIds(loadoutId, itemIds);
+        final var battlePosition = personageService.getByIdForce(personageId).position();
+        loadoutDao.updateCurrent(loadoutId, itemIds, battlePosition);
         return Either.right(loadoutDao.findById(loadoutId).orElseThrow());
     }
 
@@ -190,6 +205,7 @@ public class EquipmentLoadoutService {
         }
 
         itemDao.setEquippedForPersonage(personageId, loadout.itemIds());
+        personageService.setBattlePosition(personageId, loadout.battlePosition());
         return Either.right(Success.INSTANCE);
     }
 

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutService.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutService.java
@@ -2,6 +2,7 @@ package ru.homyakin.seeker.game.item.loadout.action;
 
 import io.vavr.control.Either;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,7 @@ import ru.homyakin.seeker.game.item.loadout.infra.postgres.EquipmentLoadoutDao;
 import ru.homyakin.seeker.game.item.models.Inventory;
 import ru.homyakin.seeker.game.item.models.PersonageItem;
 import ru.homyakin.seeker.game.personage.PersonageService;
+import ru.homyakin.seeker.game.personage.models.Personage;
 import ru.homyakin.seeker.game.personage.models.PersonageId;
 import ru.homyakin.seeker.game.personage.models.PersonageSlot;
 import ru.homyakin.seeker.utils.models.Success;
@@ -106,13 +108,28 @@ public class EquipmentLoadoutService {
         return Either.right(ToggleDefaultLoadoutResult.SET);
     }
 
-    public Map<PersonageId, ResolvedCombatGear> resolveCombatGear(Set<PersonageId> personageIds, EventType eventType) {
+    public Map<PersonageId, ResolvedCombatGear> resolveCombatGear(
+        Collection<Personage> personages,
+        EventType eventType
+    ) {
+        if (personages.isEmpty()) {
+            return Map.of();
+        }
+        final var personageIds = personages.stream()
+            .map(Personage::id)
+            .collect(Collectors.toSet());
         final var equippedByPersonageId = itemService.getEquippedItemsByPersonageIds(personageIds);
         final var result = new HashMap<PersonageId, ResolvedCombatGear>();
-        for (final var entry : equippedByPersonageId.entrySet()) {
-            result.put(entry.getKey(), ResolvedCombatGear.fromEquipped(entry.getValue()));
+        for (final var personage : personages) {
+            result.put(
+                personage.id(),
+                new ResolvedCombatGear(
+                    equippedByPersonageId.getOrDefault(personage.id(), List.of()),
+                    personage.position()
+                )
+            );
         }
-        if (personageIds.isEmpty() || !DEFAULT_LOADOUT_EVENT_TYPES.contains(eventType)) {
+        if (!DEFAULT_LOADOUT_EVENT_TYPES.contains(eventType)) {
             return result;
         }
 
@@ -136,7 +153,7 @@ public class EquipmentLoadoutService {
             }
             result.put(
                 personageId,
-                ResolvedCombatGear.fromLoadout(
+                new ResolvedCombatGear(
                     itemService.itemsWithDefaults(ownedLoadoutItems),
                     loadout.battlePosition()
                 )

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/EquipmentLoadout.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/EquipmentLoadout.java
@@ -2,6 +2,7 @@ package ru.homyakin.seeker.game.item.loadout.entity;
 
 import java.util.List;
 import java.util.Set;
+import ru.homyakin.seeker.game.battle.Position;
 import ru.homyakin.seeker.game.event.models.EventType;
 import ru.homyakin.seeker.game.personage.models.PersonageId;
 
@@ -10,6 +11,7 @@ public record EquipmentLoadout(
     PersonageId personageId,
     String name,
     List<Long> itemIds,
+    Position battlePosition,
     Set<EventType> defaultEventTypes
 ) {
     public boolean isDefaultFor(EventType eventType) {

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/ResolvedCombatGear.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/ResolvedCombatGear.java
@@ -1,23 +1,11 @@
 package ru.homyakin.seeker.game.item.loadout.entity;
 
 import java.util.List;
-import java.util.Optional;
 import ru.homyakin.seeker.game.battle.Position;
 import ru.homyakin.seeker.game.item.models.Item;
 
 public record ResolvedCombatGear(
     List<Item> items,
-    Optional<Position> battlePosition
+    Position battlePosition
 ) {
-    public static ResolvedCombatGear fromEquipped(List<Item> items) {
-        return new ResolvedCombatGear(items, Optional.empty());
-    }
-
-    public static ResolvedCombatGear fromLoadout(List<Item> items, Position battlePosition) {
-        return new ResolvedCombatGear(items, Optional.of(battlePosition));
-    }
-
-    public Position positionOr(Position fallback) {
-        return battlePosition.orElse(fallback);
-    }
 }

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/ResolvedCombatGear.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/entity/ResolvedCombatGear.java
@@ -1,0 +1,23 @@
+package ru.homyakin.seeker.game.item.loadout.entity;
+
+import java.util.List;
+import java.util.Optional;
+import ru.homyakin.seeker.game.battle.Position;
+import ru.homyakin.seeker.game.item.models.Item;
+
+public record ResolvedCombatGear(
+    List<Item> items,
+    Optional<Position> battlePosition
+) {
+    public static ResolvedCombatGear fromEquipped(List<Item> items) {
+        return new ResolvedCombatGear(items, Optional.empty());
+    }
+
+    public static ResolvedCombatGear fromLoadout(List<Item> items, Position battlePosition) {
+        return new ResolvedCombatGear(items, Optional.of(battlePosition));
+    }
+
+    public Position positionOr(Position fallback) {
+        return battlePosition.orElse(fallback);
+    }
+}

--- a/game/src/main/java/ru/homyakin/seeker/game/item/loadout/infra/postgres/EquipmentLoadoutDao.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/item/loadout/infra/postgres/EquipmentLoadoutDao.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
+import ru.homyakin.seeker.game.battle.Position;
 import ru.homyakin.seeker.game.event.models.EventType;
 import ru.homyakin.seeker.game.item.loadout.entity.EquipmentLoadout;
 import ru.homyakin.seeker.game.personage.models.PersonageId;
@@ -96,15 +97,16 @@ public class EquipmentLoadoutDao {
             .single();
     }
 
-    public long insert(PersonageId personageId, String name, List<Long> itemIds) {
+    public long insert(PersonageId personageId, String name, List<Long> itemIds, Position battlePosition) {
         return jdbcClient.sql("""
-                INSERT INTO personage_equipment_loadout (personage_id, name, item_ids)
-                VALUES (:personage_id, :name, :item_ids)
+                INSERT INTO personage_equipment_loadout (personage_id, name, item_ids, battle_position)
+                VALUES (:personage_id, :name, :item_ids, :battle_position)
                 RETURNING id
                 """)
             .param("personage_id", personageId.value())
             .param("name", name)
             .param("item_ids", itemIdsArray(itemIds))
+            .param("battle_position", battlePosition.name())
             .query((rs, _) -> rs.getLong("id"))
             .single();
     }
@@ -113,6 +115,18 @@ public class EquipmentLoadoutDao {
         jdbcClient.sql("UPDATE personage_equipment_loadout SET item_ids = :item_ids WHERE id = :id")
             .param("id", id)
             .param("item_ids", itemIdsArray(itemIds))
+            .update();
+    }
+
+    public void updateCurrent(long id, List<Long> itemIds, Position battlePosition) {
+        jdbcClient.sql("""
+                UPDATE personage_equipment_loadout
+                SET item_ids = :item_ids, battle_position = :battle_position
+                WHERE id = :id
+                """)
+            .param("id", id)
+            .param("item_ids", itemIdsArray(itemIds))
+            .param("battle_position", battlePosition.name())
             .update();
     }
 
@@ -168,6 +182,7 @@ public class EquipmentLoadoutDao {
             PersonageId.from(rs.getLong("personage_id")),
             rs.getString("name"),
             extractItemIds(rs.getArray("item_ids")),
+            Position.fromString(rs.getString("battle_position")),
             extractEventTypes(rs.getArray("default_event_type_ids"))
         );
     }
@@ -209,7 +224,7 @@ public class EquipmentLoadoutDao {
     }
 
     private static final String SELECT_SQL = """
-        SELECT id, personage_id, name, item_ids, default_event_type_ids
+        SELECT id, personage_id, name, item_ids, battle_position, default_event_type_ids
         FROM personage_equipment_loadout
         """;
 }

--- a/game/src/main/java/ru/homyakin/seeker/telegram/command/user/item/LoadoutMessageService.java
+++ b/game/src/main/java/ru/homyakin/seeker/telegram/command/user/item/LoadoutMessageService.java
@@ -12,7 +12,6 @@ import ru.homyakin.seeker.game.item.ItemService;
 import ru.homyakin.seeker.game.item.loadout.action.EquipmentLoadoutService;
 import ru.homyakin.seeker.game.item.loadout.entity.EquipmentLoadout;
 import ru.homyakin.seeker.game.item.models.PersonageItem;
-import ru.homyakin.seeker.game.personage.PersonageService;
 import ru.homyakin.seeker.game.personage.settings.action.GetPersonageSettingsCommand;
 import ru.homyakin.seeker.locale.item.ItemLocalization;
 import ru.homyakin.seeker.telegram.TelegramSender;
@@ -24,27 +23,23 @@ import ru.homyakin.seeker.telegram.utils.InlineKeyboards;
 public class LoadoutMessageService {
     private final EquipmentLoadoutService loadoutService;
     private final ItemService itemService;
-    private final PersonageService personageService;
     private final GetPersonageSettingsCommand getPersonageSettingsCommand;
     private final TelegramSender telegramSender;
 
     public LoadoutMessageService(
         EquipmentLoadoutService loadoutService,
         ItemService itemService,
-        PersonageService personageService,
         GetPersonageSettingsCommand getPersonageSettingsCommand,
         TelegramSender telegramSender
     ) {
         this.loadoutService = loadoutService;
         this.itemService = itemService;
-        this.personageService = personageService;
         this.getPersonageSettingsCommand = getPersonageSettingsCommand;
         this.telegramSender = telegramSender;
     }
 
     public void editLoadoutsList(User user, int messageId) {
         final var loadouts = loadoutService.list(user.personageId());
-        final var personage = personageService.getByIdForce(user.personageId());
         final var inventory = itemService.getPersonageItems(user.personageId());
         final var ownedById = inventory.items().stream()
             .collect(Collectors.toMap(PersonageItem::id, item -> item));
@@ -57,7 +52,7 @@ public class LoadoutMessageService {
             final var combatItems = itemService.itemsWithDefaults(wornItems);
             battleStatsByLoadoutId.put(
                 loadout.id(),
-                new BattlePersonage(combatItems, personage.position())
+                new BattlePersonage(combatItems, loadout.battlePosition())
             );
         }
         telegramSender.send(

--- a/game/src/main/resources/migrations/v.1.4/changelog.xml
+++ b/game/src/main/resources/migrations/v.1.4/changelog.xml
@@ -28,6 +28,7 @@
     <include file="changes/2026-07-18_01_migrate-duels-to-launched-events.xml" relativeToChangelogFile="true"/>
     <include file="changes/2026-07-19_01_add-equipment-loadouts.xml" relativeToChangelogFile="true"/>
     <include file="changes/2026-07-19_02_add-personage-default-loadout.xml" relativeToChangelogFile="true"/>
+    <include file="changes/2026-07-20_01_add-battle-position-to-loadout.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
 
 

--- a/game/src/main/resources/migrations/v.1.4/changes/2026-07-20_01_add-battle-position-to-loadout.xml
+++ b/game/src/main/resources/migrations/v.1.4/changes/2026-07-20_01_add-battle-position-to-loadout.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd"
+>
+    <changeSet context="legacy" author="Cursor" id="add-battle-position-to-loadout">
+        <addColumn tableName="personage_equipment_loadout">
+            <column name="battle_position" type="VARCHAR(10)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <sql>
+            UPDATE personage_equipment_loadout pel
+            SET battle_position = p.battle_position
+            FROM personage p
+            WHERE pel.personage_id = p.id
+        </sql>
+
+        <addNotNullConstraint tableName="personage_equipment_loadout" columnName="battle_position"/>
+    </changeSet>
+</databaseChangeLog>

--- a/game/src/test/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutServiceTest.java
+++ b/game/src/test/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutServiceTest.java
@@ -267,7 +267,8 @@ class EquipmentLoadoutServiceTest {
 
     @Test
     void resolveCombatGear_usesDefaultLoadoutWithoutEquipping() {
-        final var personageId = PersonageUtils.random().id();
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
@@ -288,16 +289,17 @@ class EquipmentLoadoutServiceTest {
             .thenReturn(new Inventory(List.of(ownedLoadoutItem)));
         Mockito.when(itemService.itemsWithDefaults(List.of(ownedLoadoutItem))).thenReturn(loadoutCombatItems);
 
-        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(List.of(personage), EventType.RAID);
 
         Assertions.assertEquals(loadoutCombatItems, result.get(personageId).items());
-        Assertions.assertEquals(Optional.of(Position.BACK), result.get(personageId).battlePosition());
+        Assertions.assertEquals(Position.BACK, result.get(personageId).battlePosition());
         Mockito.verify(itemDao, Mockito.never()).setEquippedForPersonage(Mockito.any(), Mockito.any());
     }
 
     @Test
     void resolveCombatGear_usesOwnedSubsetWhenSomeItemsMissing() {
-        final var personageId = PersonageUtils.random().id();
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
@@ -317,15 +319,16 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(itemService.getPersonageItems(personageId)).thenReturn(new Inventory(List.of(owned)));
         Mockito.when(itemService.itemsWithDefaults(List.of(owned))).thenReturn(loadoutCombatItems);
 
-        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(List.of(personage), EventType.RAID);
 
         Assertions.assertEquals(loadoutCombatItems, result.get(personageId).items());
-        Assertions.assertEquals(Optional.of(Position.FRONT), result.get(personageId).battlePosition());
+        Assertions.assertEquals(Position.FRONT, result.get(personageId).battlePosition());
     }
 
     @Test
     void resolveCombatGear_fallsBackToEquippedOnSlotConflicts() {
-        final var personageId = PersonageUtils.random().id();
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
@@ -345,16 +348,17 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(itemService.getPersonageItems(personageId))
             .thenReturn(new Inventory(List.of(item1, item2)));
 
-        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(List.of(personage), EventType.RAID);
 
         Assertions.assertEquals(equippedFallback, result.get(personageId).items());
-        Assertions.assertTrue(result.get(personageId).battlePosition().isEmpty());
+        Assertions.assertEquals(personage.position(), result.get(personageId).battlePosition());
         Mockito.verify(itemService, Mockito.never()).itemsWithDefaults(Mockito.any());
     }
 
     @Test
     void resolveCombatGear_fallsBackWhenNoDefault() {
-        final var personageId = PersonageUtils.random().id();
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
         final var equippedFallback = List.of(Mockito.mock(Item.class));
 
         Mockito.when(itemService.getEquippedItemsByPersonageIds(Set.of(personageId)))
@@ -362,10 +366,10 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(loadoutDao.findDefaultsByPersonageIdsAndEventType(Set.of(personageId), EventType.DUEL))
             .thenReturn(Map.of());
 
-        final var result = service.resolveCombatGear(Set.of(personageId), EventType.DUEL);
+        final var result = service.resolveCombatGear(List.of(personage), EventType.DUEL);
 
         Assertions.assertEquals(equippedFallback, result.get(personageId).items());
-        Assertions.assertTrue(result.get(personageId).battlePosition().isEmpty());
+        Assertions.assertEquals(personage.position(), result.get(personageId).battlePosition());
     }
 
     private static EquipmentLoadout loadout(

--- a/game/src/test/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutServiceTest.java
+++ b/game/src/test/java/ru/homyakin/seeker/game/item/loadout/action/EquipmentLoadoutServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import ru.homyakin.seeker.game.battle.Position;
 import ru.homyakin.seeker.game.event.models.EventType;
 import ru.homyakin.seeker.game.item.ItemService;
 import ru.homyakin.seeker.game.item.database.ItemDao;
@@ -23,6 +24,7 @@ import ru.homyakin.seeker.game.item.models.Inventory;
 import ru.homyakin.seeker.game.item.models.Item;
 import ru.homyakin.seeker.game.item.models.ItemRarity;
 import ru.homyakin.seeker.game.item.models.PersonageItem;
+import ru.homyakin.seeker.game.personage.PersonageService;
 import ru.homyakin.seeker.game.personage.models.PersonageId;
 import ru.homyakin.seeker.game.personage.models.PersonageSlot;
 import ru.homyakin.seeker.test_utils.CatalogTestUtils;
@@ -32,7 +34,13 @@ class EquipmentLoadoutServiceTest {
     private final EquipmentLoadoutDao loadoutDao = Mockito.mock(EquipmentLoadoutDao.class);
     private final ItemService itemService = Mockito.mock(ItemService.class);
     private final ItemDao itemDao = Mockito.mock(ItemDao.class);
-    private final EquipmentLoadoutService service = new EquipmentLoadoutService(loadoutDao, itemService, itemDao);
+    private final PersonageService personageService = Mockito.mock(PersonageService.class);
+    private final EquipmentLoadoutService service = new EquipmentLoadoutService(
+        loadoutDao,
+        itemService,
+        itemDao,
+        personageService
+    );
 
     @Test
     void createFromCurrent_requiresValidName() {
@@ -54,38 +62,42 @@ class EquipmentLoadoutServiceTest {
     }
 
     @Test
-    void createFromCurrent_savesEquippedItemIds() {
-        final var personageId = PersonageUtils.random().id();
+    void createFromCurrent_savesEquippedItemIdsAndBattlePosition() {
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
         final var equipped = personageItem(1L, personageId, true, PersonageSlot.MAIN_HAND);
         final var bag = personageItem(2L, personageId, false, PersonageSlot.BODY);
-        final var created = loadout(10L, personageId, "Raid", List.of(1L));
+        final var created = loadout(10L, personageId, "Raid", List.of(1L), personage.position());
 
         Mockito.when(loadoutDao.countByPersonageId(personageId)).thenReturn(0);
         Mockito.when(itemService.getPersonageItems(personageId)).thenReturn(new Inventory(List.of(equipped, bag)));
-        Mockito.when(loadoutDao.insert(personageId, "Raid", List.of(1L))).thenReturn(10L);
+        Mockito.when(personageService.getByIdForce(personageId)).thenReturn(personage);
+        Mockito.when(loadoutDao.insert(personageId, "Raid", List.of(1L), personage.position())).thenReturn(10L);
         Mockito.when(loadoutDao.findById(10L)).thenReturn(Optional.of(created));
 
         final var result = service.createFromCurrent(personageId, "Raid");
 
         Assertions.assertTrue(result.isRight());
         Assertions.assertEquals(created, result.get());
-        Mockito.verify(loadoutDao).insert(personageId, "Raid", List.of(1L));
+        Mockito.verify(loadoutDao).insert(personageId, "Raid", List.of(1L), personage.position());
     }
 
     @Test
-    void saveCurrent_updatesItemIds() {
-        final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(5L, personageId, "Old", List.of(1L));
+    void saveCurrent_updatesItemIdsAndBattlePosition() {
+        final var personage = PersonageUtils.random();
+        final var personageId = personage.id();
+        final var loadout = loadout(5L, personageId, "Old", List.of(1L), Position.FRONT);
         final var equipped = personageItem(3L, personageId, true, PersonageSlot.HELMET);
-        final var updated = loadout(5L, personageId, "Old", List.of(3L));
+        final var updated = loadout(5L, personageId, "Old", List.of(3L), personage.position());
 
         Mockito.when(loadoutDao.findById(5L)).thenReturn(Optional.of(loadout), Optional.of(updated));
         Mockito.when(itemService.getPersonageItems(personageId)).thenReturn(new Inventory(List.of(equipped)));
+        Mockito.when(personageService.getByIdForce(personageId)).thenReturn(personage);
 
         final var result = service.saveCurrent(personageId, 5L);
 
         Assertions.assertTrue(result.isRight());
-        Mockito.verify(loadoutDao).updateItemIds(5L, List.of(3L));
+        Mockito.verify(loadoutDao).updateCurrent(5L, List.of(3L), personage.position());
     }
 
     @Test
@@ -93,7 +105,7 @@ class EquipmentLoadoutServiceTest {
         final var personageId = PersonageUtils.random().id();
         final var other = PersonageUtils.random().id();
         Mockito.when(loadoutDao.findById(5L))
-            .thenReturn(Optional.of(loadout(5L, other, "X", List.of())));
+            .thenReturn(Optional.of(loadout(5L, other, "X", List.of(), Position.MID)));
 
         final var result = service.saveCurrent(personageId, 5L);
 
@@ -104,7 +116,7 @@ class EquipmentLoadoutServiceTest {
     @Test
     void apply_failsWhenItemsMissing() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(1L, personageId, "Raid", List.of(10L, 11L));
+        final var loadout = loadout(1L, personageId, "Raid", List.of(10L, 11L), Position.BACK);
         final var owned = personageItem(10L, personageId, false, PersonageSlot.MAIN_HAND);
 
         Mockito.when(loadoutDao.findById(1L)).thenReturn(Optional.of(loadout));
@@ -115,12 +127,13 @@ class EquipmentLoadoutServiceTest {
         Assertions.assertTrue(result.isLeft());
         Assertions.assertEquals(List.of(11L), ((ApplyLoadoutError.MissingItems) result.getLeft()).missingItemIds());
         Mockito.verify(itemDao, Mockito.never()).setEquippedForPersonage(Mockito.any(), Mockito.any());
+        Mockito.verify(personageService, Mockito.never()).setBattlePosition(Mockito.any(), Mockito.any());
     }
 
     @Test
     void apply_failsWhenBagWouldOverflow() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(1L, personageId, "Raid", List.of());
+        final var loadout = loadout(1L, personageId, "Raid", List.of(), Position.MID);
         // totalOwned=16, targetCount=0 -> unequipped=16 > 15
         final var bagOnly = new ArrayList<PersonageItem>();
         for (long i = 1; i <= 16; i++) {
@@ -137,9 +150,9 @@ class EquipmentLoadoutServiceTest {
     }
 
     @Test
-    void apply_setsEquippedAtomically() {
+    void apply_setsEquippedAndBattlePositionAtomically() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(1L, personageId, "Raid", List.of(2L));
+        final var loadout = loadout(1L, personageId, "Raid", List.of(2L), Position.BACK);
         final var item1 = personageItem(1L, personageId, true, PersonageSlot.MAIN_HAND);
         final var item2 = personageItem(2L, personageId, false, PersonageSlot.BODY);
 
@@ -150,13 +163,14 @@ class EquipmentLoadoutServiceTest {
 
         Assertions.assertTrue(result.isRight());
         Mockito.verify(itemDao).setEquippedForPersonage(personageId, List.of(2L));
+        Mockito.verify(personageService).setBattlePosition(personageId, Position.BACK);
     }
 
     @Test
     void rename_updatesName() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(1L, personageId, "Old", List.of());
-        final var renamed = loadout(1L, personageId, "New", List.of());
+        final var loadout = loadout(1L, personageId, "Old", List.of(), Position.MID);
+        final var renamed = loadout(1L, personageId, "New", List.of(), Position.MID);
 
         Mockito.when(loadoutDao.findById(1L)).thenReturn(Optional.of(loadout), Optional.of(renamed));
 
@@ -171,7 +185,7 @@ class EquipmentLoadoutServiceTest {
     void delete_removesLoadout() {
         final var personageId = PersonageUtils.random().id();
         Mockito.when(loadoutDao.findById(1L))
-            .thenReturn(Optional.of(loadout(1L, personageId, "Raid", List.of())));
+            .thenReturn(Optional.of(loadout(1L, personageId, "Raid", List.of(), Position.FRONT)));
 
         final var result = service.delete(personageId, 1L);
 
@@ -182,8 +196,8 @@ class EquipmentLoadoutServiceTest {
     @Test
     void removeItemFromLoadouts_prunesIdsAndReturnsNames() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout1 = loadout(1L, personageId, "A", List.of(10L, 11L));
-        final var loadout2 = loadout(2L, personageId, "B", List.of(10L));
+        final var loadout1 = loadout(1L, personageId, "A", List.of(10L, 11L), Position.MID);
+        final var loadout2 = loadout(2L, personageId, "B", List.of(10L), Position.FRONT);
 
         Mockito.when(loadoutDao.findByPersonageIdAndItemId(personageId, 10L))
             .thenReturn(List.of(loadout1, loadout2));
@@ -201,7 +215,7 @@ class EquipmentLoadoutServiceTest {
     @Test
     void toggleDefault_setsAndClears() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(1L, personageId, "Raid", List.of(10L));
+        final var loadout = loadout(1L, personageId, "Raid", List.of(10L), Position.MID);
         Mockito.when(loadoutDao.findById(1L)).thenReturn(Optional.of(loadout));
 
         final var setResult = service.toggleDefault(personageId, 1L, EventType.RAID);
@@ -216,6 +230,7 @@ class EquipmentLoadoutServiceTest {
             personageId,
             "Raid",
             List.of(10L),
+            Position.MID,
             Set.of(EventType.RAID)
         );
         Mockito.when(loadoutDao.findById(1L)).thenReturn(Optional.of(selected));
@@ -231,7 +246,7 @@ class EquipmentLoadoutServiceTest {
     @Test
     void toggleDefault_replacesPreviousDefault() {
         final var personageId = PersonageUtils.random().id();
-        final var loadout = loadout(2L, personageId, "Duel", List.of());
+        final var loadout = loadout(2L, personageId, "Duel", List.of(), Position.FRONT);
         Mockito.when(loadoutDao.findById(2L)).thenReturn(Optional.of(loadout));
 
         final var result = service.toggleDefault(personageId, 2L, EventType.DUEL);
@@ -251,13 +266,14 @@ class EquipmentLoadoutServiceTest {
     }
 
     @Test
-    void resolveCombatItems_usesDefaultLoadoutWithoutEquipping() {
+    void resolveCombatGear_usesDefaultLoadoutWithoutEquipping() {
         final var personageId = PersonageUtils.random().id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
             "Raid",
             List.of(2L),
+            Position.BACK,
             Set.of(EventType.RAID)
         );
         final var ownedLoadoutItem = personageItem(2L, personageId, false, PersonageSlot.BODY);
@@ -272,20 +288,22 @@ class EquipmentLoadoutServiceTest {
             .thenReturn(new Inventory(List.of(ownedLoadoutItem)));
         Mockito.when(itemService.itemsWithDefaults(List.of(ownedLoadoutItem))).thenReturn(loadoutCombatItems);
 
-        final var result = service.resolveCombatItems(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
 
-        Assertions.assertEquals(loadoutCombatItems, result.get(personageId));
+        Assertions.assertEquals(loadoutCombatItems, result.get(personageId).items());
+        Assertions.assertEquals(Optional.of(Position.BACK), result.get(personageId).battlePosition());
         Mockito.verify(itemDao, Mockito.never()).setEquippedForPersonage(Mockito.any(), Mockito.any());
     }
 
     @Test
-    void resolveCombatItems_usesOwnedSubsetWhenSomeItemsMissing() {
+    void resolveCombatGear_usesOwnedSubsetWhenSomeItemsMissing() {
         final var personageId = PersonageUtils.random().id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
             "Raid",
             List.of(2L, 99L),
+            Position.FRONT,
             Set.of(EventType.RAID)
         );
         final var owned = personageItem(2L, personageId, false, PersonageSlot.BODY);
@@ -299,19 +317,21 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(itemService.getPersonageItems(personageId)).thenReturn(new Inventory(List.of(owned)));
         Mockito.when(itemService.itemsWithDefaults(List.of(owned))).thenReturn(loadoutCombatItems);
 
-        final var result = service.resolveCombatItems(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
 
-        Assertions.assertEquals(loadoutCombatItems, result.get(personageId));
+        Assertions.assertEquals(loadoutCombatItems, result.get(personageId).items());
+        Assertions.assertEquals(Optional.of(Position.FRONT), result.get(personageId).battlePosition());
     }
 
     @Test
-    void resolveCombatItems_fallsBackToEquippedOnSlotConflicts() {
+    void resolveCombatGear_fallsBackToEquippedOnSlotConflicts() {
         final var personageId = PersonageUtils.random().id();
         final var loadout = new EquipmentLoadout(
             1L,
             personageId,
             "Raid",
             List.of(2L, 3L),
+            Position.BACK,
             Set.of(EventType.RAID)
         );
         final var item1 = personageItem(2L, personageId, false, PersonageSlot.BODY);
@@ -325,14 +345,15 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(itemService.getPersonageItems(personageId))
             .thenReturn(new Inventory(List.of(item1, item2)));
 
-        final var result = service.resolveCombatItems(Set.of(personageId), EventType.RAID);
+        final var result = service.resolveCombatGear(Set.of(personageId), EventType.RAID);
 
-        Assertions.assertEquals(equippedFallback, result.get(personageId));
+        Assertions.assertEquals(equippedFallback, result.get(personageId).items());
+        Assertions.assertTrue(result.get(personageId).battlePosition().isEmpty());
         Mockito.verify(itemService, Mockito.never()).itemsWithDefaults(Mockito.any());
     }
 
     @Test
-    void resolveCombatItems_fallsBackWhenNoDefault() {
+    void resolveCombatGear_fallsBackWhenNoDefault() {
         final var personageId = PersonageUtils.random().id();
         final var equippedFallback = List.of(Mockito.mock(Item.class));
 
@@ -341,13 +362,20 @@ class EquipmentLoadoutServiceTest {
         Mockito.when(loadoutDao.findDefaultsByPersonageIdsAndEventType(Set.of(personageId), EventType.DUEL))
             .thenReturn(Map.of());
 
-        final var result = service.resolveCombatItems(Set.of(personageId), EventType.DUEL);
+        final var result = service.resolveCombatGear(Set.of(personageId), EventType.DUEL);
 
-        Assertions.assertEquals(equippedFallback, result.get(personageId));
+        Assertions.assertEquals(equippedFallback, result.get(personageId).items());
+        Assertions.assertTrue(result.get(personageId).battlePosition().isEmpty());
     }
 
-    private static EquipmentLoadout loadout(long id, PersonageId personageId, String name, List<Long> itemIds) {
-        return new EquipmentLoadout(id, personageId, name, itemIds, Set.of());
+    private static EquipmentLoadout loadout(
+        long id,
+        PersonageId personageId,
+        String name,
+        List<Long> itemIds,
+        Position battlePosition
+    ) {
+        return new EquipmentLoadout(id, personageId, name, itemIds, battlePosition, Set.of());
     }
 
     private PersonageItem personageItem(long id, PersonageId personageId, boolean equipped, PersonageSlot... slots) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a non-null `battle_position` column to `personage_equipment_loadout`, backfilling existing loadouts from each personage's current `battle_position`.

### Changes
- Liquibase migration: add column → copy from `personage.battle_position` → enforce NOT NULL
- Loadout create/save snapshots current battle position; apply restores it
- `resolveCombatGear` takes already-loaded personages and always returns a full snapshot (`items` + concrete `battlePosition`) — loadout position when a default loadout applies, otherwise the personage position
- Raid / world raid callers use the resolved snapshot directly

### Notes
- Duels still force `Position.FRONT` for both fighters (unchanged behavior)
- No extra DB reads for position — callers pass personages they already loaded
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b16f2420-cf30-49d3-a664-464e39a4b55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b16f2420-cf30-49d3-a664-464e39a4b55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

