### PR TITLE
[CF] Enrich battle visualizer personage info

### DIFF
--- a/game/src/main/java/ru/homyakin/seeker/game/battle/Battle.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/Battle.java
@@ -97,7 +97,15 @@ public class Battle {
                     p.initiative(),
                     p.initiativeGauge(),
                     p.range(),
-                    p.totalThreat()
+                    p.totalThreat(),
+                    p.itemSnapshots(),
+                    p.skillSnapshots(),
+                    p.critChance(),
+                    p.dodgeChance(),
+                    p.critMultiplier(),
+                    p.attacksByRange(),
+                    p.defenses(),
+                    p.defenseReductions()
                 )
             )
         );

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattleItemInitSnapshot.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattleItemInitSnapshot.java
@@ -1,0 +1,11 @@
+package ru.homyakin.seeker.game.battle;
+
+import java.util.Optional;
+import ru.homyakin.seeker.game.item.models.ItemRarity;
+
+public record BattleItemInitSnapshot(
+    Optional<String> code,
+    ItemRarity rarity,
+    Optional<String> modifier
+) {
+}

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattleItemInitSnapshot.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattleItemInitSnapshot.java
@@ -1,11 +1,12 @@
 package ru.homyakin.seeker.game.battle;
 
 import java.util.Optional;
+import ru.homyakin.seeker.game.battle.skill.active_impl.ActiveEnum;
 import ru.homyakin.seeker.game.item.models.ItemRarity;
 
 public record BattleItemInitSnapshot(
-    Optional<String> code,
+    String code,
     ItemRarity rarity,
-    Optional<String> modifier
+    Optional<ActiveEnum> skill
 ) {
 }

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonage.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonage.java
@@ -203,9 +203,9 @@ public class BattlePersonage {
             }
             if (shouldSnapshotItem(item)) {
                 builtItemSnapshots.add(new BattleItemInitSnapshot(
-                    Optional.ofNullable(item.object().code()),
+                    item.object().code(),
                     item.rarity(),
-                    item.modifier().map(Modifier::code)
+                    item.modifier().map(Modifier::activeEnum)
                 ));
             }
         }
@@ -287,10 +287,7 @@ public class BattlePersonage {
     }
 
     private static boolean shouldSnapshotItem(Item item) {
-        return item.object().code() != null
-            || item.itemAttack().isPresent()
-            || item.itemDefense().isPresent()
-            || item.modifier().isPresent();
+        return item.object().code() != null;
     }
 
     private void applyPersonageEffects(List<Item> items, PersonageEffects effects) {

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonage.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonage.java
@@ -7,6 +7,7 @@ import ru.homyakin.seeker.game.item.models.ItemAttack;
 import ru.homyakin.seeker.game.item.models.ItemDefense;
 import ru.homyakin.seeker.game.item.models.ItemObject;
 import ru.homyakin.seeker.game.item.models.ItemRarity;
+import ru.homyakin.seeker.game.item.models.Modifier;
 import ru.homyakin.seeker.game.event.world_raid.entity.WorldRaidPersonage;
 import ru.homyakin.seeker.game.personage.models.Characteristics;
 import ru.homyakin.seeker.game.personage.models.PersonageSlot;
@@ -90,6 +91,8 @@ public class BattlePersonage {
     private int health;
     private final Set<AttackType> attackTypes = new HashSet<>();
     private final List<ItemSkill> itemSkills = new ArrayList<>();
+    private final List<BattleItemInitSnapshot> itemSnapshots;
+    private final List<BattleSkillInitSnapshot> skillSnapshots;
     private final Map<AttackType, Integer>[] rangeAttack;
     private final Map<AttackType, Integer>[] rangeAttackCrit;
     private final Map<DefenseType, Integer> defense;
@@ -185,6 +188,7 @@ public class BattlePersonage {
         var totalCritMultiplier = BASE_CRIT_MULTIPLIER;
         var totalSpeed = 0;
         var totalBaseThreat = 0;
+        final var builtItemSnapshots = new ArrayList<BattleItemInitSnapshot>();
         for (final var item : items) {
             totalCritChance += item.critChance();
             totalDodgeChance += item.dodgeChance();
@@ -197,16 +201,27 @@ public class BattlePersonage {
             if (item.modifier().isPresent() && item.rarity() != ItemRarity.COMMON) {
                 activeSkills.merge(item.modifier().get().activeEnum(), item.skillPoints(), Integer::sum);
             }
+            if (shouldSnapshotItem(item)) {
+                builtItemSnapshots.add(new BattleItemInitSnapshot(
+                    Optional.ofNullable(item.object().code()),
+                    item.rarity(),
+                    item.modifier().map(Modifier::code)
+                ));
+            }
         }
+        this.itemSnapshots = List.copyOf(builtItemSnapshots);
         for (final var entry : skillPointsByActive.entrySet()) {
             activeSkills.put(entry.getKey(), activeSkills.getOrDefault(entry.getKey(), 0) + entry.getValue());
         }
         this.critMultiplier = totalCritMultiplier;
+        final var builtSkillSnapshots = new ArrayList<BattleSkillInitSnapshot>();
         for (final var entry : activeSkills.entrySet()) {
             if (entry.getValue() > 0) {
                 itemSkills.add(SkillMapper.map(entry.getKey(), entry.getValue()));
+                builtSkillSnapshots.add(new BattleSkillInitSnapshot(entry.getKey(), entry.getValue()));
             }
         }
+        this.skillSnapshots = List.copyOf(builtSkillSnapshots);
         for (final var skill : itemSkills) {
             switch (skill) {
                 case TurnSkill.TurnStartSkill turnStartSkill -> turnStartSkills.add(turnStartSkill);
@@ -269,6 +284,13 @@ public class BattlePersonage {
 
     int slotOneAttackSum() {
         return rangeAttack[1].values().stream().mapToInt(Integer::intValue).sum();
+    }
+
+    private static boolean shouldSnapshotItem(Item item) {
+        return item.object().code() != null
+            || item.itemAttack().isPresent()
+            || item.itemDefense().isPresent()
+            || item.modifier().isPresent();
     }
 
     private void applyPersonageEffects(List<Item> items, PersonageEffects effects) {
@@ -724,8 +746,24 @@ public class BattlePersonage {
         return Map.copyOf(rangeAttack[slot]);
     }
 
+    public List<BattleRangeAttackInitSnapshot> attacksByRange() {
+        final var attacks = new ArrayList<BattleRangeAttackInitSnapshot>();
+        for (int i = 1; i < rangeAttack.length; i++) {
+            attacks.add(new BattleRangeAttackInitSnapshot(i, Map.copyOf(rangeAttack[i])));
+        }
+        return List.copyOf(attacks);
+    }
+
     public Map<AttackType, Double> defenseReductions() {
         return Map.copyOf(defenseReduce);
+    }
+
+    public List<BattleItemInitSnapshot> itemSnapshots() {
+        return itemSnapshots;
+    }
+
+    public List<BattleSkillInitSnapshot> skillSnapshots() {
+        return skillSnapshots;
     }
 
     public int initiative() {

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonageInitSnapshot.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattlePersonageInitSnapshot.java
@@ -1,7 +1,11 @@
 package ru.homyakin.seeker.game.battle;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import ru.homyakin.seeker.game.item.models.AttackType;
+import ru.homyakin.seeker.game.item.models.DefenseType;
 
 public record BattlePersonageInitSnapshot(
     UUID id,
@@ -13,6 +17,14 @@ public record BattlePersonageInitSnapshot(
     int initiative,
     int initiativeGauge,
     int range,
-    int totalThreat
+    int totalThreat,
+    List<BattleItemInitSnapshot> items,
+    List<BattleSkillInitSnapshot> skills,
+    int critChance,
+    int dodgeChance,
+    double critMultiplier,
+    List<BattleRangeAttackInitSnapshot> attacksByRange,
+    Map<DefenseType, Integer> defenses,
+    Map<AttackType, Double> damageTakenMultipliers
 ) {
 }

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattleRangeAttackInitSnapshot.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattleRangeAttackInitSnapshot.java
@@ -1,0 +1,10 @@
+package ru.homyakin.seeker.game.battle;
+
+import java.util.Map;
+import ru.homyakin.seeker.game.item.models.AttackType;
+
+public record BattleRangeAttackInitSnapshot(
+    int range,
+    Map<AttackType, Integer> attack
+) {
+}

--- a/game/src/main/java/ru/homyakin/seeker/game/battle/BattleSkillInitSnapshot.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/battle/BattleSkillInitSnapshot.java
@@ -1,0 +1,9 @@
+package ru.homyakin.seeker.game.battle;
+
+import ru.homyakin.seeker.game.battle.skill.active_impl.ActiveEnum;
+
+public record BattleSkillInitSnapshot(
+    ActiveEnum code,
+    int points
+) {
+}

--- a/game/src/test/java/ru/homyakin/seeker/game/battle/BattleInitSnapshotTest.java
+++ b/game/src/test/java/ru/homyakin/seeker/game/battle/BattleInitSnapshotTest.java
@@ -6,34 +6,46 @@ import ru.homyakin.seeker.game.battle.skill.active_impl.ActiveEnum;
 import ru.homyakin.seeker.game.item.models.AttackType;
 import ru.homyakin.seeker.game.item.models.DefenseType;
 import ru.homyakin.seeker.game.item.models.Item;
+import ru.homyakin.seeker.game.item.models.ItemAttack;
+import ru.homyakin.seeker.game.item.models.ItemDefense;
+import ru.homyakin.seeker.game.item.models.ItemObject;
 import ru.homyakin.seeker.game.item.models.ItemRarity;
 import ru.homyakin.seeker.game.item.models.Modifier;
+import ru.homyakin.seeker.game.personage.models.PersonageSlot;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class BattleInitSnapshotTest {
     @Test
     public void initSnapshotIncludesItemsSkillsAndCharacteristics() {
         final var items = List.of(
-            Item.weapon(AttackType.SLASH, 1, 150, new Modifier(ActiveEnum.KNOCKBACK), ItemRarity.COMMON),
-            Item.armor(DefenseType.PLATE, 200, 800, new Modifier(ActiveEnum.BLEEDING), ItemRarity.LEGENDARY),
-            Item.armor(DefenseType.PLATE, 50, 500, new Modifier(ActiveEnum.BLEEDING), ItemRarity.LEGENDARY)
+            catalogWeapon("sword", AttackType.SLASH, 1, 150, ActiveEnum.KNOCKBACK, ItemRarity.COMMON),
+            catalogArmor("cuirass", DefenseType.PLATE, 200, 800, ActiveEnum.BLEEDING, ItemRarity.LEGENDARY),
+            catalogArmor("greaves", DefenseType.PLATE, 50, 500, ActiveEnum.BLEEDING, ItemRarity.LEGENDARY)
         );
         final var personage = new BattlePersonage(
             items,
             Position.FRONT,
-            java.util.Map.of(ActiveEnum.BLEEDING, 4)
+            Map.of(ActiveEnum.BLEEDING, 4)
         );
         final var result = new Battle().process(List.of(personage), List.of(
             new BattlePersonage(
-                List.of(Item.weapon(AttackType.PIERCE, 1, 100, new Modifier(ActiveEnum.FEINT), ItemRarity.COMMON)),
+                List.of(catalogWeapon("rapier", AttackType.PIERCE, 1, 100, ActiveEnum.FEINT, ItemRarity.COMMON)),
                 Position.FRONT
             )
         ));
 
         final var snap = result.initState().personagesById().get(personage.id());
         Assertions.assertNotNull(snap);
-        Assertions.assertFalse(snap.items().isEmpty());
+        Assertions.assertEquals(3, snap.items().size());
+        Assertions.assertEquals("sword", snap.items().getFirst().code());
+        Assertions.assertEquals(ItemRarity.COMMON, snap.items().getFirst().rarity());
+        Assertions.assertEquals(Optional.of(ActiveEnum.KNOCKBACK), snap.items().getFirst().skill());
+        Assertions.assertEquals("cuirass", snap.items().get(1).code());
+        Assertions.assertEquals(Optional.of(ActiveEnum.BLEEDING), snap.items().get(1).skill());
         Assertions.assertEquals(1, snap.skills().size());
         Assertions.assertEquals(ActiveEnum.BLEEDING, snap.skills().getFirst().code());
         Assertions.assertTrue(snap.skills().getFirst().points() > 0);
@@ -43,5 +55,59 @@ public class BattleInitSnapshotTest {
         Assertions.assertTrue(snap.damageTakenMultipliers().containsKey(AttackType.SLASH));
         Assertions.assertTrue(snap.damageTakenMultipliers().get(AttackType.SLASH) > 0);
         Assertions.assertTrue(snap.damageTakenMultipliers().get(AttackType.SLASH) <= 1);
+    }
+
+    private static Item catalogWeapon(
+        String code,
+        AttackType attackType,
+        int range,
+        int attack,
+        ActiveEnum skill,
+        ItemRarity rarity
+    ) {
+        return new Item(
+            new ItemObject(
+                code,
+                Set.of(PersonageSlot.MAIN_HAND),
+                Optional.of(new ItemAttack(attackType, range, attack)),
+                Optional.empty(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                Map.of()
+            ),
+            Optional.of(new Modifier(skill)),
+            rarity
+        );
+    }
+
+    private static Item catalogArmor(
+        String code,
+        DefenseType defenseType,
+        int defense,
+        int health,
+        ActiveEnum skill,
+        ItemRarity rarity
+    ) {
+        return new Item(
+            new ItemObject(
+                code,
+                Set.of(PersonageSlot.BODY),
+                Optional.empty(),
+                Optional.of(new ItemDefense(defenseType, defense)),
+                health,
+                0,
+                0,
+                0,
+                0,
+                0,
+                Map.of()
+            ),
+            Optional.of(new Modifier(skill)),
+            rarity
+        );
     }
 }

--- a/game/src/test/java/ru/homyakin/seeker/game/battle/BattleInitSnapshotTest.java
+++ b/game/src/test/java/ru/homyakin/seeker/game/battle/BattleInitSnapshotTest.java
@@ -1,0 +1,47 @@
+package ru.homyakin.seeker.game.battle;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.homyakin.seeker.game.battle.skill.active_impl.ActiveEnum;
+import ru.homyakin.seeker.game.item.models.AttackType;
+import ru.homyakin.seeker.game.item.models.DefenseType;
+import ru.homyakin.seeker.game.item.models.Item;
+import ru.homyakin.seeker.game.item.models.ItemRarity;
+import ru.homyakin.seeker.game.item.models.Modifier;
+
+import java.util.List;
+
+public class BattleInitSnapshotTest {
+    @Test
+    public void initSnapshotIncludesItemsSkillsAndCharacteristics() {
+        final var items = List.of(
+            Item.weapon(AttackType.SLASH, 1, 150, new Modifier(ActiveEnum.KNOCKBACK), ItemRarity.COMMON),
+            Item.armor(DefenseType.PLATE, 200, 800, new Modifier(ActiveEnum.BLEEDING), ItemRarity.LEGENDARY),
+            Item.armor(DefenseType.PLATE, 50, 500, new Modifier(ActiveEnum.BLEEDING), ItemRarity.LEGENDARY)
+        );
+        final var personage = new BattlePersonage(
+            items,
+            Position.FRONT,
+            java.util.Map.of(ActiveEnum.BLEEDING, 4)
+        );
+        final var result = new Battle().process(List.of(personage), List.of(
+            new BattlePersonage(
+                List.of(Item.weapon(AttackType.PIERCE, 1, 100, new Modifier(ActiveEnum.FEINT), ItemRarity.COMMON)),
+                Position.FRONT
+            )
+        ));
+
+        final var snap = result.initState().personagesById().get(personage.id());
+        Assertions.assertNotNull(snap);
+        Assertions.assertFalse(snap.items().isEmpty());
+        Assertions.assertEquals(1, snap.skills().size());
+        Assertions.assertEquals(ActiveEnum.BLEEDING, snap.skills().getFirst().code());
+        Assertions.assertTrue(snap.skills().getFirst().points() > 0);
+        Assertions.assertFalse(snap.attacksByRange().isEmpty());
+        Assertions.assertEquals(150, snap.attacksByRange().getFirst().attack().get(AttackType.SLASH));
+        Assertions.assertEquals(250, snap.defenses().get(DefenseType.PLATE));
+        Assertions.assertTrue(snap.damageTakenMultipliers().containsKey(AttackType.SLASH));
+        Assertions.assertTrue(snap.damageTakenMultipliers().get(AttackType.SLASH) > 0);
+        Assertions.assertTrue(snap.damageTakenMultipliers().get(AttackType.SLASH) <= 1);
+    }
+}

--- a/website/battle-visualizer/index.html
+++ b/website/battle-visualizer/index.html
@@ -310,8 +310,31 @@
     width: 36px; height: 36px; border-radius: 8px; font-size: 18px; cursor: pointer; flex: 0 0 auto;
   }
   #detail .d-body { padding: 14px 16px; overflow-y: auto; }
-  #detail .d-section-title { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); margin: 14px 0 8px; }
-  #detail .d-section-title:first-child { margin-top: 0; }
+  #detail .d-section { margin-top: 12px; }
+  #detail .d-section:first-child { margin-top: 0; }
+  #detail .d-section-toggle {
+    width: 100%; display: flex; align-items: center; gap: 8px;
+    background: transparent; border: none; color: var(--muted); cursor: pointer;
+    padding: 4px 0; margin: 0 0 8px; text-align: left;
+    font: inherit; font-size: 11px; text-transform: uppercase; letter-spacing: 1px;
+  }
+  #detail .d-section-toggle:hover { color: var(--text); }
+  #detail .d-section-toggle .chevron {
+    width: 0; height: 0; flex: 0 0 auto;
+    border-left: 5px solid currentColor;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    transform: rotate(90deg);
+    transition: transform 140ms ease;
+  }
+  #detail .d-section.collapsed .d-section-toggle .chevron { transform: rotate(0deg); }
+  #detail .d-section.collapsed .d-section-toggle { margin-bottom: 0; }
+  #detail .d-section-title-text { flex: 1; min-width: 0; }
+  #detail .d-section-title-text .hint {
+    text-transform: none; letter-spacing: 0; font-weight: 600;
+  }
+  #detail .d-section-body { display: block; }
+  #detail .d-section.collapsed .d-section-body { display: none; }
   .hp-big { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
   .hp-big .bar { flex: 1; height: 16px; }
   .hp-big .bar .label { font-size: 11px; }
@@ -515,6 +538,8 @@ let playTimer = null;
 let playSpeedMs = 200;
 let openDetailId = null;
 let nameFilter = ""; // lowercased personage-name query for the log + battlefield
+/** @type {Record<string, boolean>} section key -> collapsed */
+const detailSectionCollapsed = Object.create(null);
 
 const qs = new URLSearchParams(location.search);
 
@@ -1173,6 +1198,31 @@ function scrollLogToCursor() {
 function openDetail(id) { openDetailId = id; renderDetail(id); el.overlay.classList.add("show"); }
 function closeDetail() { openDetailId = null; el.overlay.classList.remove("show"); }
 
+function detailSection(key, titleHtml, bodyHtml) {
+  const collapsed = !!detailSectionCollapsed[key];
+  return `<section class="d-section${collapsed ? " collapsed" : ""}" data-section="${escapeHtml(key)}">
+    <button type="button" class="d-section-toggle" aria-expanded="${collapsed ? "false" : "true"}">
+      <span class="chevron" aria-hidden="true"></span>
+      <span class="d-section-title-text">${titleHtml}</span>
+    </button>
+    <div class="d-section-body">${bodyHtml}</div>
+  </section>`;
+}
+
+function bindDetailSections() {
+  el.dBody.querySelectorAll(".d-section-toggle").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const section = btn.closest(".d-section");
+      if (!section) return;
+      const key = section.dataset.section;
+      const collapsed = !section.classList.contains("collapsed");
+      section.classList.toggle("collapsed", collapsed);
+      btn.setAttribute("aria-expanded", collapsed ? "false" : "true");
+      detailSectionCollapsed[key] = collapsed;
+    });
+  });
+}
+
 function renderDetail(id) {
   const p = live[id];
   const m = meta[id];
@@ -1194,17 +1244,17 @@ function renderDetail(id) {
     <div class="bar gauge ${gPct >= 100 ? "ready" : ""}" style="height:12px"><div class="fill" style="width:${gPct}%"></div><div class="label">${p.gauge} / ${GAUGE_MAX} gauge</div></div>
   </div>`;
 
-  html += `<div class="d-section-title">Attributes</div>`;
-  html += `<div class="grid">`;
-  html += stat("Initiative", p.initiative);
-  html += stat("Range", p.range);
-  html += stat("Threat", threatText(p));
-  html += stat("Line", `${p.lineIndex} (${posOfLine(p.lineIndex)})`);
-  if (p.critChance != null) html += stat("Crit chance", `${p.critChance}%`);
-  if (p.dodgeChance != null) html += stat("Dodge chance", `${p.dodgeChance}%`);
-  if (p.critMultiplier != null) html += stat("Crit mult", Number(p.critMultiplier).toFixed(2));
-  html += stat("Full ID", `<span style="font-size:11px;font-family:ui-monospace,monospace">${escapeHtml(String(p.id))}</span>`);
-  html += `</div>`;
+  let attrs = `<div class="grid">`;
+  attrs += stat("Initiative", p.initiative);
+  attrs += stat("Range", p.range);
+  attrs += stat("Threat", threatText(p));
+  attrs += stat("Line", `${p.lineIndex} (${posOfLine(p.lineIndex)})`);
+  if (p.critChance != null) attrs += stat("Crit chance", `${p.critChance}%`);
+  if (p.dodgeChance != null) attrs += stat("Dodge chance", `${p.dodgeChance}%`);
+  if (p.critMultiplier != null) attrs += stat("Crit mult", Number(p.critMultiplier).toFixed(2));
+  attrs += stat("Full ID", `<span style="font-size:11px;font-family:ui-monospace,monospace">${escapeHtml(String(p.id))}</span>`);
+  attrs += `</div>`;
+  html += detailSection("attributes", "Attributes", attrs);
 
   html += renderItemsSection(p);
   html += renderSkillsSection(p);
@@ -1212,22 +1262,22 @@ function renderDetail(id) {
   html += renderDefensesSection(p);
   html += renderDamageTakenSection(p);
 
-  html += `<div class="d-section-title">Combat so far</div>`;
-  html += `<div class="grid">`;
-  html += stat("Damage dealt", p.dmgDealt);
-  html += stat("Damage taken", p.dmgTaken);
-  html += stat("Hits landed", p.hitsLanded);
-  html += stat("Crits", p.critsDealt);
-  html += stat("Kills", p.kills);
-  html += stat("Healing", p.healed);
-  html += stat("Dodges", p.dodged);
-  html += stat("Skill hits", p.skillsUsed);
-  html += `</div>`;
+  let combat = `<div class="grid">`;
+  combat += stat("Damage dealt", p.dmgDealt);
+  combat += stat("Damage taken", p.dmgTaken);
+  combat += stat("Hits landed", p.hitsLanded);
+  combat += stat("Crits", p.critsDealt);
+  combat += stat("Kills", p.kills);
+  combat += stat("Healing", p.healed);
+  combat += stat("Dodges", p.dodged);
+  combat += stat("Skill hits", p.skillsUsed);
+  combat += `</div>`;
+  html += detailSection("combat", "Combat so far", combat);
 
-  html += `<div class="d-section-title">Timeline (up to current step)</div>`;
-  html += renderTimeline(id);
+  html += detailSection("timeline", "Timeline (up to current step)", renderTimeline(id));
 
   el.dBody.innerHTML = html;
+  bindDetailSections();
 }
 
 function itemCodeLabel(item) {
@@ -1246,54 +1296,50 @@ function itemSkillCode(item) {
 }
 
 function renderItemsSection(p) {
-  let html = `<div class="d-section-title">Items</div>`;
   const items = p.items || [];
+  let body;
   if (!p.hasExtendedStats) {
-    html += `<div class="tag-row"><span class="tag empty">No item data (older battle log)</span></div>`;
-    return html;
+    body = `<div class="tag-row"><span class="tag empty">No item data (older battle log)</span></div>`;
+  } else if (!items.length) {
+    body = `<div class="tag-row"><span class="tag empty">No items</span></div>`;
+  } else {
+    body = `<div class="tag-row">`;
+    for (const item of items) {
+      const rarity = item.rarity ? String(item.rarity) : "—";
+      const code = itemCodeLabel(item) || "—";
+      const skill = itemSkillCode(item);
+      const bits = [
+        `<span class="muted">${escapeHtml(rarity)}</span>`,
+        `<b>${escapeHtml(code)}</b>`,
+      ];
+      if (skill) bits.push(`<span class="muted">${escapeHtml(skill)}</span>`);
+      body += `<span class="tag">${bits.join(" ")}</span>`;
+    }
+    body += `</div>`;
   }
-  if (!items.length) {
-    html += `<div class="tag-row"><span class="tag empty">No items</span></div>`;
-    return html;
-  }
-  html += `<div class="tag-row">`;
-  for (const item of items) {
-    const rarity = item.rarity ? String(item.rarity) : "—";
-    const code = itemCodeLabel(item) || "—";
-    const skill = itemSkillCode(item);
-    const bits = [
-      `<span class="muted">${escapeHtml(rarity)}</span>`,
-      `<b>${escapeHtml(code)}</b>`,
-    ];
-    if (skill) bits.push(`<span class="muted">${escapeHtml(skill)}</span>`);
-    html += `<span class="tag">${bits.join(" ")}</span>`;
-  }
-  html += `</div>`;
-  return html;
+  return detailSection("items", "Items", body);
 }
 
 function renderSkillsSection(p) {
-  let html = `<div class="d-section-title">Skills</div>`;
   const skills = p.skills || [];
+  let body;
   if (!p.hasExtendedStats) {
-    html += `<div class="tag-row"><span class="tag empty">No skill data (older battle log)</span></div>`;
-    return html;
+    body = `<div class="tag-row"><span class="tag empty">No skill data (older battle log)</span></div>`;
+  } else if (!skills.length) {
+    body = `<div class="tag-row"><span class="tag empty">No skills</span></div>`;
+  } else {
+    body = `<div class="tag-row">`;
+    for (const skill of skills) {
+      const code = typeof skill === "string" ? skill : (skill.code || "");
+      const points = typeof skill === "object" && skill != null && skill.points != null ? skill.points : null;
+      const label = points != null
+        ? `${escapeHtml(String(code))} <span class="muted">×${escapeHtml(String(points))}</span>`
+        : escapeHtml(String(code));
+      body += `<span class="tag skill">${label}</span>`;
+    }
+    body += `</div>`;
   }
-  if (!skills.length) {
-    html += `<div class="tag-row"><span class="tag empty">No skills</span></div>`;
-    return html;
-  }
-  html += `<div class="tag-row">`;
-  for (const skill of skills) {
-    const code = typeof skill === "string" ? skill : (skill.code || "");
-    const points = typeof skill === "object" && skill != null && skill.points != null ? skill.points : null;
-    const label = points != null
-      ? `${escapeHtml(String(code))} <span class="muted">×${escapeHtml(String(points))}</span>`
-      : escapeHtml(String(code));
-    html += `<span class="tag skill">${label}</span>`;
-  }
-  html += `</div>`;
-  return html;
+  return detailSection("skills", "Skills", body);
 }
 
 function addPercentInt(value, percent) {
@@ -1308,72 +1354,72 @@ function currentAttackValue(base, buffs) {
 
 function renderAttacksSection(p) {
   const rows = p.attacksByRange || [];
-  let html = `<div class="d-section-title">Attack by range`;
+  let title = "Attack by range";
   if ((p.attackBuffs || []).length) {
     const sum = p.attackBuffs.reduce((a, b) => a + b, 0);
-    html += ` <span style="color:var(--buff);font-weight:600;text-transform:none;letter-spacing:0">(+${sum}% applied)</span>`;
+    title += ` <span class="hint" style="color:var(--buff)">(+${sum}% applied)</span>`;
   }
-  html += `</div>`;
+  let body;
   if (!rows.length) {
-    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No attacks" : "No attack data (older battle log)"}</span></div>`;
-    return html;
-  }
-  html += `<table class="stat-table"><thead><tr><th>Range</th><th>Type</th><th>Attack</th></tr></thead><tbody>`;
-  for (const slot of rows) {
-    const attack = slot.attack || {};
-    const types = Object.keys(attack);
-    if (!types.length) {
-      html += `<tr><td class="num">${slot.range}</td><td class="mono" colspan="2">—</td></tr>`;
-      continue;
+    body = `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No attacks" : "No attack data (older battle log)"}</span></div>`;
+  } else {
+    body = `<table class="stat-table"><thead><tr><th>Range</th><th>Type</th><th>Attack</th></tr></thead><tbody>`;
+    for (const slot of rows) {
+      const attack = slot.attack || {};
+      const types = Object.keys(attack);
+      if (!types.length) {
+        body += `<tr><td class="num">${slot.range}</td><td class="mono" colspan="2">—</td></tr>`;
+        continue;
+      }
+      types.forEach((type, i) => {
+        const cur = currentAttackValue(attack[type], p.attackBuffs);
+        const base = Number(attack[type]);
+        const shown = (p.attackBuffs || []).length && cur !== base
+          ? `${cur} <span style="color:var(--muted);font-weight:500">(${base})</span>`
+          : String(cur);
+        body += `<tr>`;
+        body += i === 0 ? `<td class="num" rowspan="${types.length}">${slot.range}</td>` : "";
+        body += `<td class="mono">${escapeHtml(type)}</td><td class="num">${shown}</td></tr>`;
+      });
     }
-    types.forEach((type, i) => {
-      const cur = currentAttackValue(attack[type], p.attackBuffs);
-      const base = Number(attack[type]);
-      const shown = (p.attackBuffs || []).length && cur !== base
-        ? `${cur} <span style="color:var(--muted);font-weight:500">(${base})</span>`
-        : String(cur);
-      html += `<tr>`;
-      html += i === 0 ? `<td class="num" rowspan="${types.length}">${slot.range}</td>` : "";
-      html += `<td class="mono">${escapeHtml(type)}</td><td class="num">${shown}</td></tr>`;
-    });
+    body += `</tbody></table>`;
   }
-  html += `</tbody></table>`;
-  return html;
+  return detailSection("attacks", title, body);
 }
 
 function renderDefensesSection(p) {
   const defenses = p.defenses || {};
   const types = Object.keys(defenses);
-  let html = `<div class="d-section-title">Defense by type</div>`;
+  let body;
   if (!types.length) {
-    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No defenses" : "No defense data (older battle log)"}</span></div>`;
-    return html;
+    body = `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No defenses" : "No defense data (older battle log)"}</span></div>`;
+  } else {
+    body = `<div class="grid">`;
+    for (const type of types) {
+      body += `<div class="kv"><div class="k">${escapeHtml(type)}</div><div class="v">${defenses[type]}</div></div>`;
+    }
+    body += `</div>`;
   }
-  html += `<div class="grid">`;
-  for (const type of types) {
-    html += `<div class="kv"><div class="k">${escapeHtml(type)}</div><div class="v">${defenses[type]}</div></div>`;
-  }
-  html += `</div>`;
-  return html;
+  return detailSection("defenses", "Defense by type", body);
 }
 
 function renderDamageTakenSection(p) {
   const mults = p.damageTakenMultipliers || {};
   const types = Object.keys(mults);
-  let html = `<div class="d-section-title">Damage taken by attack type</div>`;
+  let body;
   if (!types.length) {
-    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No mitigation" : "No mitigation data (older battle log)"}</span></div>`;
-    return html;
+    body = `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No mitigation" : "No mitigation data (older battle log)"}</span></div>`;
+  } else {
+    body = `<table class="stat-table"><thead><tr><th>Attack</th><th>Taken</th><th>Reduced</th></tr></thead><tbody>`;
+    for (const type of types) {
+      const mult = Number(mults[type]);
+      const takenPct = (mult * 100).toFixed(1);
+      const reducedPct = ((1 - mult) * 100).toFixed(1);
+      body += `<tr><td class="mono">${escapeHtml(type)}</td><td class="num">${takenPct}%</td><td class="num">${reducedPct}%</td></tr>`;
+    }
+    body += `</tbody></table>`;
   }
-  html += `<table class="stat-table"><thead><tr><th>Attack</th><th>Taken</th><th>Reduced</th></tr></thead><tbody>`;
-  for (const type of types) {
-    const mult = Number(mults[type]);
-    const takenPct = (mult * 100).toFixed(1);
-    const reducedPct = ((1 - mult) * 100).toFixed(1);
-    html += `<tr><td class="mono">${escapeHtml(type)}</td><td class="num">${takenPct}%</td><td class="num">${reducedPct}%</td></tr>`;
-  }
-  html += `</tbody></table>`;
-  return html;
+  return detailSection("damageTaken", "Damage taken by attack type", body);
 }
 
 function posOfLine(lineIndex) { const l = lineByIndex[lineIndex]; return l ? l.position : "?"; }

--- a/website/battle-visualizer/index.html
+++ b/website/battle-visualizer/index.html
@@ -1237,6 +1237,14 @@ function itemCodeLabel(item) {
   return null;
 }
 
+function itemSkillCode(item) {
+  if (!item || typeof item !== "object") return null;
+  // Prefer skill (ActiveEnum), fall back to legacy modifier field from earlier drafts.
+  if (item.skill) return String(item.skill);
+  if (item.modifier) return String(item.modifier);
+  return null;
+}
+
 function renderItemsSection(p) {
   let html = `<div class="d-section-title">Items</div>`;
   const items = p.items || [];
@@ -1250,15 +1258,14 @@ function renderItemsSection(p) {
   }
   html += `<div class="tag-row">`;
   for (const item of items) {
-    const code = itemCodeLabel(item);
-    const rarity = item.rarity ? String(item.rarity) : "";
-    const mod = item.modifier ? String(item.modifier) : "";
-    const bits = [];
-    if (code) bits.push(`<b>${escapeHtml(code)}</b>`);
-    else if (mod) bits.push(`<b>${escapeHtml(mod)}</b>`);
-    else bits.push(`<b>—</b>`);
-    if (rarity) bits.push(`<span class="muted">${escapeHtml(rarity)}</span>`);
-    if (code && mod) bits.push(`<span class="muted">+${escapeHtml(mod)}</span>`);
+    const rarity = item.rarity ? String(item.rarity) : "—";
+    const code = itemCodeLabel(item) || "—";
+    const skill = itemSkillCode(item);
+    const bits = [
+      `<span class="muted">${escapeHtml(rarity)}</span>`,
+      `<b>${escapeHtml(code)}</b>`,
+    ];
+    if (skill) bits.push(`<span class="muted">${escapeHtml(skill)}</span>`);
     html += `<span class="tag">${bits.join(" ")}</span>`;
   }
   html += `</div>`;

--- a/website/battle-visualizer/index.html
+++ b/website/battle-visualizer/index.html
@@ -293,7 +293,7 @@
   #overlay.show { display: flex; }
   #detail {
     background: var(--panel); border: 1px solid var(--border); border-radius: 14px;
-    width: 100%; max-width: 520px; max-height: 86vh; max-height: 86dvh;
+    width: 100%; max-width: 560px; max-height: 86vh; max-height: 86dvh;
     display: flex; flex-direction: column; overflow: hidden;
     box-shadow: 0 20px 60px rgba(0,0,0,0.5);
   }
@@ -324,6 +324,25 @@
   }
   .kv .k { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
   .kv .v { font-size: 15px; font-weight: 700; }
+  .kv .v.small { font-size: 12px; font-weight: 600; word-break: break-word; }
+  .tag-row { display: flex; flex-wrap: wrap; gap: 6px; }
+  .tag {
+    font-size: 11px; padding: 4px 8px; border-radius: 6px;
+    background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
+    font-family: ui-monospace, monospace;
+  }
+  .tag .muted { color: var(--muted); }
+  .tag.skill { border-color: rgba(120, 200, 255, 0.35); color: var(--skill); }
+  .tag.empty { color: var(--muted-2); font-style: italic; font-family: inherit; }
+  .stat-table {
+    width: 100%; border-collapse: collapse; font-size: 12px;
+  }
+  .stat-table th, .stat-table td {
+    text-align: left; padding: 6px 8px; border-bottom: 1px solid rgba(255,255,255,0.05);
+  }
+  .stat-table th { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600; }
+  .stat-table td.num { font-variant-numeric: tabular-nums; font-weight: 700; }
+  .stat-table td.mono { font-family: ui-monospace, monospace; font-size: 11px; }
   .timeline { display: flex; flex-direction: column; gap: 0; }
   .timeline .tl {
     font-size: 12px; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
@@ -672,6 +691,23 @@ function buildInitialLive() {
       lineIndex: p.lineIndex, advanceDirection: p.advanceDirection,
       initiative: p.initiative, gauge: p.initiativeGauge,
       range: p.range, threat: p.totalThreat, baseThreat: p.totalThreat, alive: true,
+      // characteristics / loadout (optional on older battle-init JSON)
+      hasExtendedStats: p.critChance != null
+        || Array.isArray(p.items)
+        || Array.isArray(p.skills)
+        || Array.isArray(p.attacksByRange)
+        || (p.defenses && typeof p.defenses === "object")
+        || (p.damageTakenMultipliers && typeof p.damageTakenMultipliers === "object"),
+      items: Array.isArray(p.items) ? p.items : [],
+      skills: Array.isArray(p.skills) ? p.skills : [],
+      critChance: p.critChance ?? null,
+      dodgeChance: p.dodgeChance ?? null,
+      critMultiplier: p.critMultiplier ?? null,
+      attacksByRange: Array.isArray(p.attacksByRange) ? p.attacksByRange : [],
+      defenses: p.defenses && typeof p.defenses === "object" ? p.defenses : {},
+      damageTakenMultipliers: p.damageTakenMultipliers && typeof p.damageTakenMultipliers === "object"
+        ? p.damageTakenMultipliers : {},
+      attackBuffs: [],
       // accumulated stats
       dmgDealt: 0, dmgTaken: 0, healed: 0, kills: 0, hitsLanded: 0,
       critsDealt: 0, dodged: 0, missed: 0, skillsUsed: 0,
@@ -760,7 +796,11 @@ function applyEvent(ev) {
     }
     case "PersonageAttackBuffed": {
       const p = live[ev.personageId];
-      if (p) { p.flash = "buff"; p.popup = { text: "+" + ev.attackBonusPercent + "% ATK", kind: "buff" }; }
+      if (p) {
+        p.flash = "buff";
+        p.popup = { text: "+" + ev.attackBonusPercent + "% ATK", kind: "buff" };
+        if (typeof ev.attackBonusPercent === "number") p.attackBuffs.push(ev.attackBonusPercent);
+      }
       break;
     }
     case "PersonageDefeated": {
@@ -965,7 +1005,6 @@ function renderCard(p) {
     <div class="mini-stats">
       <span>rng <b>${p.range}</b></span>
       <span>thr <b>${threatText(p)}</b></span>
-      <span>${p.advanceDirection === "TOWARD_SECOND_TEAM" ? "→" : "←"}</span>
     </div>
   `;
   if (p.popup) {
@@ -1161,9 +1200,17 @@ function renderDetail(id) {
   html += stat("Range", p.range);
   html += stat("Threat", threatText(p));
   html += stat("Line", `${p.lineIndex} (${posOfLine(p.lineIndex)})`);
-  html += stat("Advance", p.advanceDirection === "TOWARD_SECOND_TEAM" ? "→ team 2" : "← team 1");
+  if (p.critChance != null) html += stat("Crit chance", `${p.critChance}%`);
+  if (p.dodgeChance != null) html += stat("Dodge chance", `${p.dodgeChance}%`);
+  if (p.critMultiplier != null) html += stat("Crit mult", Number(p.critMultiplier).toFixed(2));
   html += stat("Full ID", `<span style="font-size:11px;font-family:ui-monospace,monospace">${escapeHtml(String(p.id))}</span>`);
   html += `</div>`;
+
+  html += renderItemsSection(p);
+  html += renderSkillsSection(p);
+  html += renderAttacksSection(p);
+  html += renderDefensesSection(p);
+  html += renderDamageTakenSection(p);
 
   html += `<div class="d-section-title">Combat so far</div>`;
   html += `<div class="grid">`;
@@ -1181,6 +1228,143 @@ function renderDetail(id) {
   html += renderTimeline(id);
 
   el.dBody.innerHTML = html;
+}
+
+function itemCodeLabel(item) {
+  if (!item) return "—";
+  if (item.code) return String(item.code);
+  if (typeof item === "string") return item;
+  return "—";
+}
+
+function renderItemsSection(p) {
+  let html = `<div class="d-section-title">Items</div>`;
+  const items = p.items || [];
+  if (!p.hasExtendedStats) {
+    html += `<div class="tag-row"><span class="tag empty">No item data (older battle log)</span></div>`;
+    return html;
+  }
+  if (!items.length) {
+    html += `<div class="tag-row"><span class="tag empty">No items</span></div>`;
+    return html;
+  }
+  html += `<div class="tag-row">`;
+  for (const item of items) {
+    const code = itemCodeLabel(item);
+    const rarity = item.rarity ? String(item.rarity) : "";
+    const mod = item.modifier ? String(item.modifier) : "";
+    const bits = [];
+    bits.push(`<b>${escapeHtml(code)}</b>`);
+    if (rarity) bits.push(`<span class="muted">${escapeHtml(rarity)}</span>`);
+    if (mod) bits.push(`<span class="muted">+${escapeHtml(mod)}</span>`);
+    html += `<span class="tag">${bits.join(" ")}</span>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function renderSkillsSection(p) {
+  let html = `<div class="d-section-title">Skills</div>`;
+  const skills = p.skills || [];
+  if (!p.hasExtendedStats) {
+    html += `<div class="tag-row"><span class="tag empty">No skill data (older battle log)</span></div>`;
+    return html;
+  }
+  if (!skills.length) {
+    html += `<div class="tag-row"><span class="tag empty">No skills</span></div>`;
+    return html;
+  }
+  html += `<div class="tag-row">`;
+  for (const skill of skills) {
+    const code = typeof skill === "string" ? skill : (skill.code || "");
+    const points = typeof skill === "object" && skill != null && skill.points != null ? skill.points : null;
+    const label = points != null
+      ? `${escapeHtml(String(code))} <span class="muted">×${escapeHtml(String(points))}</span>`
+      : escapeHtml(String(code));
+    html += `<span class="tag skill">${label}</span>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function addPercentInt(value, percent) {
+  return Math.round(Number(value) * (1 + Number(percent) / 100));
+}
+
+function currentAttackValue(base, buffs) {
+  let v = Number(base) || 0;
+  for (const pct of buffs || []) v = addPercentInt(v, pct);
+  return v;
+}
+
+function renderAttacksSection(p) {
+  const rows = p.attacksByRange || [];
+  let html = `<div class="d-section-title">Attack by range`;
+  if ((p.attackBuffs || []).length) {
+    const sum = p.attackBuffs.reduce((a, b) => a + b, 0);
+    html += ` <span style="color:var(--buff);font-weight:600;text-transform:none;letter-spacing:0">(+${sum}% applied)</span>`;
+  }
+  html += `</div>`;
+  if (!rows.length) {
+    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No attacks" : "No attack data (older battle log)"}</span></div>`;
+    return html;
+  }
+  html += `<table class="stat-table"><thead><tr><th>Range</th><th>Type</th><th>Attack</th></tr></thead><tbody>`;
+  for (const slot of rows) {
+    const attack = slot.attack || {};
+    const types = Object.keys(attack);
+    if (!types.length) {
+      html += `<tr><td class="num">${slot.range}</td><td class="mono" colspan="2">—</td></tr>`;
+      continue;
+    }
+    types.forEach((type, i) => {
+      const cur = currentAttackValue(attack[type], p.attackBuffs);
+      const base = Number(attack[type]);
+      const shown = (p.attackBuffs || []).length && cur !== base
+        ? `${cur} <span style="color:var(--muted);font-weight:500">(${base})</span>`
+        : String(cur);
+      html += `<tr>`;
+      html += i === 0 ? `<td class="num" rowspan="${types.length}">${slot.range}</td>` : "";
+      html += `<td class="mono">${escapeHtml(type)}</td><td class="num">${shown}</td></tr>`;
+    });
+  }
+  html += `</tbody></table>`;
+  return html;
+}
+
+function renderDefensesSection(p) {
+  const defenses = p.defenses || {};
+  const types = Object.keys(defenses);
+  let html = `<div class="d-section-title">Defense by type</div>`;
+  if (!types.length) {
+    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No defenses" : "No defense data (older battle log)"}</span></div>`;
+    return html;
+  }
+  html += `<div class="grid">`;
+  for (const type of types) {
+    html += `<div class="kv"><div class="k">${escapeHtml(type)}</div><div class="v">${defenses[type]}</div></div>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function renderDamageTakenSection(p) {
+  const mults = p.damageTakenMultipliers || {};
+  const types = Object.keys(mults);
+  let html = `<div class="d-section-title">Damage taken by attack type</div>`;
+  if (!types.length) {
+    html += `<div class="tag-row"><span class="tag empty">${p.hasExtendedStats ? "No mitigation" : "No mitigation data (older battle log)"}</span></div>`;
+    return html;
+  }
+  html += `<table class="stat-table"><thead><tr><th>Attack</th><th>Taken</th><th>Reduced</th></tr></thead><tbody>`;
+  for (const type of types) {
+    const mult = Number(mults[type]);
+    const takenPct = (mult * 100).toFixed(1);
+    const reducedPct = ((1 - mult) * 100).toFixed(1);
+    html += `<tr><td class="mono">${escapeHtml(type)}</td><td class="num">${takenPct}%</td><td class="num">${reducedPct}%</td></tr>`;
+  }
+  html += `</tbody></table>`;
+  return html;
 }
 
 function posOfLine(lineIndex) { const l = lineByIndex[lineIndex]; return l ? l.position : "?"; }

--- a/website/battle-visualizer/index.html
+++ b/website/battle-visualizer/index.html
@@ -1231,10 +1231,10 @@ function renderDetail(id) {
 }
 
 function itemCodeLabel(item) {
-  if (!item) return "—";
-  if (item.code) return String(item.code);
+  if (!item) return null;
   if (typeof item === "string") return item;
-  return "—";
+  if (item.code) return String(item.code);
+  return null;
 }
 
 function renderItemsSection(p) {
@@ -1254,9 +1254,11 @@ function renderItemsSection(p) {
     const rarity = item.rarity ? String(item.rarity) : "";
     const mod = item.modifier ? String(item.modifier) : "";
     const bits = [];
-    bits.push(`<b>${escapeHtml(code)}</b>`);
+    if (code) bits.push(`<b>${escapeHtml(code)}</b>`);
+    else if (mod) bits.push(`<b>${escapeHtml(mod)}</b>`);
+    else bits.push(`<b>—</b>`);
     if (rarity) bits.push(`<span class="muted">${escapeHtml(rarity)}</span>`);
-    if (mod) bits.push(`<span class="muted">+${escapeHtml(mod)}</span>`);
+    if (code && mod) bits.push(`<span class="muted">+${escapeHtml(mod)}</span>`);
     html += `<span class="tag">${bits.join(" ")}</span>`;
   }
   html += `</div>`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the **Advance** block from personage cards and the detail modal (`advanceDirection` remains in battle-init JSON for compatibility).
- Extends `BattlePersonageInitSnapshot` with items, aggregated skills, and combat characteristics: crit/dodge/crit mult, attack by type & range, defense by type, damage-taken multipliers by attack type.
- Each item is stored/shown as **rarity + catalog item code + skill code** (e.g. `LEGENDARY cuirass BLEEDING`), using object codes from `item_objects_catalog.toml`. Only items with a code are included.
- Personage profile sections are **collapse/expand** toggles (state kept across replay redraws).
- Older battle logs without the new fields still load with clear fallbacks. Attack buffs during replay update displayed attack values.

## Walkthrough
[Battlefield overview](https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbattlefield.webp)
[Personage detail with rarity + item code + skill](https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdetail-items-skills.webp)
[Attack, defense, and damage-taken characteristics](https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdetail-characteristics.webp)
[Collapsible profile sections](https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdetail-collapsible-sections.webp)
[Older battle log placeholders](https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdetail-old-format.webp)

## Test plan
- [x] `cd game && mvn checkstyle:check` + unit tests
- [x] `BattleInitSnapshotTest` covers catalog item codes + skill codes
- [x] Visualizer new/old battle-init load checks
- [x] Collapse/expand toggles on profile sections


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad186387-bda1-4674-ba17-34e533b43181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad186387-bda1-4674-ba17-34e533b43181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

