### PR TITLE
[CF] Raise max raid level to 50

### DIFF
--- a/game/src/main/java/ru/homyakin/seeker/game/group/action/UpdateGroupParameters.java
+++ b/game/src/main/java/ru/homyakin/seeker/game/group/action/UpdateGroupParameters.java
@@ -26,7 +26,7 @@ public class UpdateGroupParameters {
     public void updateRaidLevel(GroupId groupId, boolean wasRaidSuccess) {
         final var group = storage.get(groupId).orElseThrow();
         final var newRaidLevel = Math.min(
-            25,
+            50,
             Math.max(1, group.raidLevel() + (wasRaidSuccess ? 1 : -2))
         );
         storage.updateRaidLevel(groupId, newRaidLevel);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Raises the group raid level cap from 25 to 50 in `UpdateGroupParameters`.

Contraband tiers already cover levels above 45 (EPIC), and raid item rarity scales with level, so no other config changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9937e62-2320-4023-ae93-f0b7a083364b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9937e62-2320-4023-ae93-f0b7a083364b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

